### PR TITLE
more efficient parent cell repartioning

### DIFF
--- a/vector2dggs/h3.py
+++ b/vector2dggs/h3.py
@@ -44,8 +44,6 @@ DEFAULT_PARENT_OFFSET = 6
 class ParentResolutionException(Exception):
     pass
 
-class EmptyDataException(Exception):
-    pass
 
 def _get_parent_res(parent_res: Union[None, int], resolution: int):
     """


### PR DESCRIPTION
Closes #14 

Output data is structured:
`{user-specified-output-directory}/{partition-cell}.parquet/part.{n}.parquet`

The `part.{n}.parquet` comes from the original spatial sort (default Hilbert); the same part can then appear in multiple `{partition-cell}.parquet` subdirectories, but these only include data from the first-pass parts that actually include cells under that partition key (parent cell). This saves a whole cycle of reindexing, which was what was causing OOM errors.