### PR TITLE
Fix SQL identifier handling for PostGIS database reads

### DIFF
--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -561,20 +561,21 @@ def index(
     if layer and con:
         # Database connection
         with con.connect() as connection:
-            query = None
-            params = {"layer": layer}
+            parts = layer.rsplit(".", 1)
+            schema, tbl_name = (parts[0], parts[1]) if len(parts) == 2 else (None, parts[0])
+            tbl = sqlalchemy.table(tbl_name, schema=schema)
 
             if keep_attributes:
-                query = f"SELECT * FROM {layer}"
+                stmt = tbl.select()
             elif id_field and not keep_attributes:
-                query = sqlalchemy.text("SELECT :id_field, :geom_col FROM :layer")
-                params.update({"id_field": id_field, "geom_col": geom_col})
+                stmt = sqlalchemy.select(
+                    sqlalchemy.column(id_field), sqlalchemy.column(geom_col)
+                ).select_from(tbl)
             else:
-                query = sqlalchemy.text("SELECT :geom_col FROM :layer")
-                params["geom_col"] = geom_col
+                stmt = sqlalchemy.select(sqlalchemy.column(geom_col)).select_from(tbl)
 
             df = gpd.read_postgis(
-                query, connection, geom_col=geom_col, params=params
+                stmt, connection, geom_col=geom_col
             ).rename_geometry("geometry")
     else:
         # Read file


### PR DESCRIPTION
Use SQLAlchemy expression language (table/column/select) instead of sqlalchemy.text() with bind parameters, which cannot substitute identifiers. Also supports schema-qualified layer names.

## Summary

- Replace broken `sqlalchemy.text()` + bind-parameter approach for PostGIS reads: bind params are for values, not identifiers (column/table names), so `:geom_col`, `:layer` etc. were never valid here
- Fix SQL injection risk in the `keep_attributes` branch, which was using a bare f-string with the user-supplied `layer` name
- Use `sqlalchemy.table()` / `sqlalchemy.column()` / `sqlalchemy.select()` instead — SQLAlchemy handles identifier quoting internally
- Support schema-qualified layer names (e.g. `public.my_table`) by splitting on `.` before constructing the `table()` clause

Closes #69 