### PR TITLE
Floor --threads at 1 to prevent crash on single-core hosts

### DIFF
--- a/tests/classes/output_validation.py
+++ b/tests/classes/output_validation.py
@@ -83,3 +83,14 @@ class TestOutputValidation(TestRunthrough):
         table = pq.read_table(self._parquet_files()[0])
         self.assertIn("Name_2018", table.schema.names)
         self.assertIn("LCDB_UID", table.schema.names)
+
+    def test_zero_threads_does_not_crash(self):
+        """--threads 0 (e.g. from a single-core cpu_count()-1 default) must not
+        crash ProcessPoolExecutor; it should be floored to at least 1 worker."""
+        self._run_h3(("-t", "0"))
+        self._parquet_files()
+
+    def test_negative_threads_does_not_crash(self):
+        """A negative --threads value should likewise be floored to 1 worker."""
+        self._run_h3(("-t", "-1"))
+        self._parquet_files()

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -682,7 +682,7 @@ def _run_dggs_indexing(
         )
         for filepath in filepaths
     ]
-    with ProcessPoolExecutor(max_workers=processes) as executor:
+    with ProcessPoolExecutor(max_workers=max(1, processes)) as executor:
         futures = {executor.submit(_polyfill_star, arg): arg for arg in args}
         for future in tqdm(
             as_completed(futures), total=len(futures), desc="DGGS indexing"

--- a/vector2dggs/constants.py
+++ b/vector2dggs/constants.py
@@ -190,7 +190,7 @@ DEFAULTS = {
     "s": SpatialSortingMethod.NONE.value,
     "crs": None,
     "c": None,
-    "t": (multiprocessing.cpu_count() - 1),
+    "t": max(1, multiprocessing.cpu_count() - 1),
     "cp": "snappy",
     "lyr": None,
     "g": "geom",


### PR DESCRIPTION
## Summary
- `DEFAULTS["t"] = multiprocessing.cpu_count() - 1` resolves to `0` on single-vCPU hosts (small VMs, cgroup-limited containers). `_run_dggs_indexing`'s `ProcessPoolExecutor(max_workers=processes)` then raises `ValueError: max_workers must be greater than 0` before any indexing happens.
- Floors the computed default to at least 1, and guards the `ProcessPoolExecutor` call site the same way `_run_bisection` already guards its own use of the same `processes` value (`max(1, processes)`).
- Adds regression tests for `--threads 0` and `--threads -1`.

Closes #80

## Test plan
- [x] New tests (`test_zero_threads_does_not_crash`, `test_negative_threads_does_not_crash`) confirmed to fail without the fix, pass with it
- [x] Full test suite passes (134/134)

🤖 Generated with [Claude Code](https://claude.com/claude-code)