### PR TITLE
Fix no-op else branch in S2 polyfill_polygons

### DIFF
--- a/vector2dggs/indexers/s2vectorindexer.py
+++ b/vector2dggs/indexers/s2vectorindexer.py
@@ -150,7 +150,7 @@ class S2VectorIndexer(VectorIndexer):
                     if self.cell_center_is_inside_polygon(cell, s2polygon)
                 }
             else:
-                set(covering)
+                covering = set(covering)
 
             return covering
 


### PR DESCRIPTION
## Summary
`generate_covering`'s `else` branch built `set(covering)` but never assigned it back:

```python
else:
    set(covering)
```

Fixed to `covering = set(covering)`.

Closes #81

## Note on test coverage
`centroid_inside` is always called with its default (`True`) from the one call site (`generate_covering(geom, level)`), so this branch isn't reachable via the public CLI/API today, and there's no existing hook to exercise it from outside the module without also exposing `centroid_inside` as a real option (out of scope for this fix). Flagging here rather than silently claiming coverage that doesn't exist.

## Test plan
- [x] Full test suite passes (132/132) — this branch is a no-op fix with no behavioural change reachable by current tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)