### PR TITLE
Remove stale unimplemented GPL startup-notice comment

### DIFF
--- a/vector2dggs/cli.py
+++ b/vector2dggs/cli.py
@@ -7,14 +7,6 @@ from vector2dggs.rHP import rhp
 from vector2dggs.s2 import s2
 from vector2dggs.geohash import geohash
 
-#   If the program does terminal interaction, make it output a short
-# notice like this when it starts in an interactive mode:
-
-#     <program>  Copyright (C) <year>  <name of author>
-#     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-#     This is free software, and you are welcome to redistribute it
-#     under certain conditions; type `show c' for details.
-
 
 @click.group()
 @click.version_option(version=__version__)


### PR DESCRIPTION
## Summary
`cli.py` had a leftover boilerplate comment reminding the author to print a copyright/warranty notice on interactive startup. It was never implemented and `cli()` does nothing but `pass`. Removed the dead comment.

Closes #83

## Test plan
- [x] `black --check` passes
- [x] Full test suite passes (132/132)

🤖 Generated with [Claude Code](https://claude.com/claude-code)