### PR TITLE
Migrate s2geometry 0.9.0 -> 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ In brief, to get started:
     - If you're on Windows, `pip install gdal` may be necessary before running the subsequent commands.
     - On Linux, install GDAL 3.13.1+ according to your platform-specific instructions, including development headers, i.e. `libgdal-dev`. The Python `gdal` bindings must be matched by an equal-or-newer system `libgdal`.
 - Create and populate the virtual environment with `poetry install`. This will install necessary dependencies.
-  - If the installation of `s2geometry` fails, you may require SWIG to build it. (A command like `conda install -c conda-forge swig` or `sudo dnf install swig` depending on your platform).
 - Subsequently, activate the virtual environment with `eval "$(poetry env activate)"`.
 
 If you run `poetry install -E all --with dev` and activate the environment with `eval "$(poetry env activate)"`, the CLI tool will be aliased so you can simply use `vector2dggs` rather than `poetry run vector2dggs`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -2397,18 +2397,17 @@ files = [
 
 [[package]]
 name = "s2geometry"
-version = "0.9.0"
+version = "0.14.0"
 description = "Computational geometry and spatial indexing on the sphere"
 optional = true
-python-versions = ">=3.4"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"s2\" or extra == \"all\""
 files = [
-    {file = "s2geometry-0.9.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:ba100731d1639dd8022e61a211bf200ce25044409f6db1dd93fd1ebaab22774b"},
-    {file = "s2geometry-0.9.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fd99d1d6ef8c96a0238c32a7aae06a20c8b6dedc1eeeb33636719f68ec968ee1"},
-    {file = "s2geometry-0.9.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a8001325310f214bbdee380b9695978b2e3b56e0c5e9fc7889a36b53ad877537"},
-    {file = "s2geometry-0.9.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:59dc034a8e83d4312cd436c594ae45f2c04bc8ae075973df41cf3a3ef2989676"},
-    {file = "s2geometry-0.9.0.tar.gz", hash = "sha256:ae395d8966e2865c4df93ab9e1b712f00b18308d064f64a01bf67fdaf9491e28"},
+    {file = "s2geometry-0.14.0-cp310-abi3-macosx_10_13_x86_64.whl", hash = "sha256:4d676bdafb34b6b224da5af534e8cefe751e6e2d33b2684ebaffbe82e655717a"},
+    {file = "s2geometry-0.14.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:28a884595c971760f94af51560533b136fb7b6827fff3952e6151b8bb102f9d3"},
+    {file = "s2geometry-0.14.0-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7797370df5446002629c5014ec525f8f50ce27f039a71dbf6e957ded539bb13"},
+    {file = "s2geometry-0.14.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:082141d54b23d7f5faa199db5e87fe3513a4c93ab5f50429894f23de3f705dde"},
 ]
 
 [[package]]
@@ -2885,4 +2884,4 @@ s2 = ["s2geometry"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "b91b97ec1d4074b3221bbe0af33fd2be45221f5073536b684cddd69d14cf3cd7"
+content-hash = "485c4d081c80a473109498891996d80edb16e9b58c9f280f852829b662f8a4ed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ pillow = "^12.2"
 h3 = { version = "^4.1", optional = true }
 rhppandas = { version = "^0.2.0", optional = true}
 rhealpixdggs = { version = "^0.5.12", optional = true}
-s2geometry = { version = "^0.9.0", optional = true}
+s2geometry = { version = "^0.14.0", optional = true}
 rusty-polygon-geohasher = { version = "^0.2.3", optional = true}
 python-geohash = { version = "^0.8.5", optional = true}
 pya5 = { version = "^0.9.0", optional = true }

--- a/tests/classes/compaction.py
+++ b/tests/classes/compaction.py
@@ -5,7 +5,7 @@ import a5
 import h3
 import pandas as pd
 from rhealpixdggs.rhp_wrappers import rhp_get_resolution
-from s2geometry import pywraps2 as S2
+import s2geometry as S2
 
 from vector2dggs.indexers.vectorindexer import VectorIndexer
 from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer
@@ -137,9 +137,7 @@ class TestRHPCompactionBounds(TestCase):
         self.res = self.parent_res + 1
         self.indexer = RHPVectorIndexer(dggs="rhp")
         digits = "012345678"
-        self.cells = {
-            self.ancestor + a + b for a, b in product(digits, repeat=2)
-        }
+        self.cells = {self.ancestor + a + b for a, b in product(digits, repeat=2)}
 
     def test_unbounded_compaction_would_exceed_parent_res(self):
         # Demonstrates the underlying behaviour that necessitates the floor:
@@ -164,9 +162,7 @@ class TestRHPCompactionBounds(TestCase):
         )
 
         digits = "012345678"
-        self.assertTrue(
-            all(rhp_get_resolution(c) >= self.parent_res for c in result)
-        )
+        self.assertTrue(all(rhp_get_resolution(c) >= self.parent_res for c in result))
         self.assertEqual(result, {self.ancestor + d for d in digits})
 
     def test_compaction_respects_parent_res(self):
@@ -219,7 +215,7 @@ class TestS2CompactionBounds(TestCase):
 
     @staticmethod
     def _get_resolution(token):
-        return S2.S2CellId.FromToken(token, len(token)).level()
+        return S2.S2CellId.FromToken(token).level()
 
     def test_unbounded_compaction_would_exceed_parent_res(self):
         # Demonstrates the underlying behaviour that necessitates the floor:
@@ -245,9 +241,7 @@ class TestS2CompactionBounds(TestCase):
             self.indexer.children_at_res,
         )
 
-        self.assertTrue(
-            all(self._get_resolution(c) >= self.parent_res for c in result)
-        )
+        self.assertTrue(all(self._get_resolution(c) >= self.parent_res for c in result))
         self.assertEqual(result, self._descendants(self.ancestor_id, self.parent_res))
 
     def test_compaction_respects_parent_res(self):
@@ -293,13 +287,10 @@ class TestA5CompactionBounds(TestCase):
         # a5.compact has no resolution floor and will compact past
         # parent_res whenever the cells fully cover a coarser ancestor.
         unbounded = {
-            a5.u64_to_hex(c)
-            for c in a5.compact([a5.hex_to_u64(c) for c in self.cells])
+            a5.u64_to_hex(c) for c in a5.compact([a5.hex_to_u64(c) for c in self.cells])
         }
         self.assertEqual(unbounded, {self.ancestor})
-        self.assertLess(
-            A5VectorIndexer.get_resolution(self.ancestor), self.parent_res
-        )
+        self.assertLess(A5VectorIndexer.get_resolution(self.ancestor), self.parent_res)
 
     def test_children_at_res(self):
         result = self.indexer.children_at_res(self.ancestor, self.parent_res)
@@ -325,7 +316,10 @@ class TestA5CompactionBounds(TestCase):
         self.assertTrue(
             all(A5VectorIndexer.get_resolution(c) >= self.parent_res for c in result)
         )
-        self.assertEqual(set(result), set(self.indexer.children_at_res(self.ancestor, self.parent_res)))
+        self.assertEqual(
+            set(result),
+            set(self.indexer.children_at_res(self.ancestor, self.parent_res)),
+        )
 
     def test_compaction_respects_parent_res(self):
         dggs_col = f"a5_{self.res:02}"

--- a/vector2dggs/indexers/s2vectorindexer.py
+++ b/vector2dggs/indexers/s2vectorindexer.py
@@ -4,7 +4,7 @@ from math import ceil
 import pandas as pd
 import geopandas as gpd
 
-from s2geometry import pywraps2 as S2
+import s2geometry as S2
 from shapely import force_2d
 from shapely.geometry import box, Polygon, LineString, Point
 from shapely.ops import transform
@@ -213,7 +213,8 @@ class S2VectorIndexer(VectorIndexer):
         """
 
         latlngs = [S2.S2LatLng.FromDegrees(lat, lon) for lon, lat in linestring.coords]
-        polyline = S2.S2Polyline(latlngs)
+        polyline = S2.S2Polyline()
+        polyline.InitFromS2LatLngs(latlngs)
 
         coverer = S2.S2RegionCoverer()
         max_cells = self.max_cells_for_geom(linestring, level)
@@ -239,9 +240,7 @@ class S2VectorIndexer(VectorIndexer):
 
         Not a part of the interface provided by VectorIndexer.
         """
-        cell_ids: list[S2.S2CellId] = [
-            S2.S2CellId.FromToken(token, len(token)) for token in tokens
-        ]
+        cell_ids: list[S2.S2CellId] = [S2.S2CellId.FromToken(token) for token in tokens]
         cell_union: S2.S2CellUnion = S2.S2CellUnion(
             cell_ids
         )  # Vector of sorted, non-overlapping S2CellId
@@ -255,7 +254,7 @@ class S2VectorIndexer(VectorIndexer):
 
         Not a part of the interface provided by VectorIndexer.
         """
-        return S2.S2CellId.FromToken(token, len(token)).level()
+        return S2.S2CellId.FromToken(token).level()
 
     @staticmethod
     def children_at_res(token: str, target_level: int) -> list[str]:
@@ -265,7 +264,7 @@ class S2VectorIndexer(VectorIndexer):
 
         Not a part of the interface provided by VectorIndexer.
         """
-        cell: S2.S2CellId = S2.S2CellId.FromToken(token, len(token))
+        cell: S2.S2CellId = S2.S2CellId.FromToken(token)
         if target_level <= cell.level():
             return [token]
         end = cell.child_end(target_level)
@@ -283,7 +282,7 @@ class S2VectorIndexer(VectorIndexer):
 
         Not a part of the interface provided by VectorIndexer.
         """
-        cell: S2.S2CellId = S2.S2CellId.FromToken(token, len(token))
+        cell: S2.S2CellId = S2.S2CellId.FromToken(token)
         if level <= cell.level():
             raise ValueError(
                 "Level must be greater than the current level of the cell."
@@ -293,13 +292,13 @@ class S2VectorIndexer(VectorIndexer):
 
     @staticmethod
     def cell_to_point(cell: str) -> Point:
-        cell_id = S2.S2CellId.FromToken(cell, len(cell))
+        cell_id = S2.S2CellId.FromToken(cell)
         latlng = cell_id.ToLatLng()
         return Point(latlng.lng().degrees(), latlng.lat().degrees())
 
     @staticmethod
     def cell_to_polygon(cell: str) -> Polygon:
-        s2_cell = S2.S2Cell(S2.S2CellId.FromToken(cell, len(cell)))
+        s2_cell = S2.S2Cell(S2.S2CellId.FromToken(cell))
         return Polygon(
             tuple(
                 (


### PR DESCRIPTION
## Summary

Discovered while getting CI to actually run the test suite (#86): `s2geometry` 0.9.0 has no prebuilt wheel for Python 3.11+, so it must compile from source via SWIG+CMake on every fresh install. That build fails against current conda-forge SWIG (4.4.1) with `SWIG_Python_TypeError` undeclared. Verified in a properly isolated environment (no leaked PATH from other envs) that this isn't a "just downgrade SWIG" problem: it fails identically against SWIG 4.1.1 and even 3.0.12, with the wrapper `.cxx` regenerated fresh from `s2.i` each time. This was silently masked locally by a poetry-cached wheel built before other environment changes made earlier in this session — a genuinely fresh install (or CI) hits the failure.

`s2geometry` 0.14.0 (latest on PyPI) ships prebuilt wheels (`cp310-abi3`, manylinux + macOS) — zero compilation needed. It drops the old `pywraps2` submodule for a flatter top-level API, otherwise very close to the old SWIG binding. Verified every S2 API call used in `s2vectorindexer.py` against the new binding in an isolated venv; three concrete differences:

- `from s2geometry import pywraps2 as S2` -> `import s2geometry as S2`
- `S2Polyline(latlngs)` (constructor from list) -> `S2Polyline(); polyline.InitFromS2LatLngs(latlngs)`
- `S2CellId.FromToken(token, len(token))` -> `S2CellId.FromToken(token)` (single-arg now)

Everything else (`S2LatLng.FromDegrees`, `S2Loop(list)`, `.Normalize()`, `S2Polygon().InitNested()`, `S2RegionCoverer` + covering methods, `S2Cell`/`.GetCenter()`/`.Contains()`, `S2CellUnion` + `NormalizeS2CellUnion()`, `.ToToken()`/`.level()`/`.child_begin()`/`.child_end()`/`.next()`/`.ToLatLng()`/`.lng().degrees()`/`.lat().degrees()`/`GetS2LatLngVertex`) is unchanged.

Also updates `tests/classes/compaction.py` for the same two API changes, and drops the README's now-unneeded SWIG install note.

Closes #92

## Test plan
- [x] Verified every S2 API call against s2geometry 0.14.0 in an isolated venv before touching the indexer
- [x] Full test suite passes (132/132), including all 24 S2 tests
- [x] `black --check` passes
- [x] Manual end-to-end CLI run against real test fixture data, confirmed correct S2 cell IDs and parent partitioning in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)