### PR TITLE
Add a CI job that actually runs the test suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,3 +14,29 @@ jobs:
         uses : 'actions/checkout@v3'
       - name : 'manaakiwhenua-standards'
         uses : manaakiwhenua/manaakiwhenua-standards@v0.2.2
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Micromamba (Python + GDAL)
+        uses: mamba-org/setup-micromamba@v3.1.0
+        with:
+          environment-name: vector2dggs-ci
+          create-args: >-
+            python=3.11
+            gdal=3.13.1
+
+      - name: Install Poetry
+        shell: bash -el {0}
+        run: pip install poetry
+
+      - name: Install dependencies
+        shell: bash -el {0}
+        run: poetry install -E all --with dev
+
+      - name: Run tests
+        shell: bash -el {0}
+        run: poetry run pytest tests/


### PR DESCRIPTION
## Summary

`manaakiwhenua-standards` (the only thing `main.yml` currently ran) only checks for a non-empty README and LICENSE file — confirmed by reading its `entrypoint.sh` directly, and by observing that recent CI runs on this repo complete in ~11-20s, far too fast to install dependencies and run a 65-second test suite.

Adds a `test` job using micromamba to provision Python + GDAL 3.13.1 from conda-forge (apt's default GDAL is too old for the `>=3.13.1` floor set in `pyproject.toml`), then `poetry install -E all --with dev && poetry run pytest tests/`.

**Stacked on #93** (the s2geometry migration) — that PR needed to land first because `s2geometry` 0.9.0 can't build in a fresh CI environment at all (see #93 for the full story). This PR's base will need retargeting to `main` once #93 merges.

Closes #86

## Test plan
- [x] Watched the actual CI run on this branch (run 30408053922) — `build` and `test` jobs both green, `test` completing in 2m46s running the real suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)