### PR TITLE
Bump actions/checkout to v7 to drop Node.js 20 deprecation warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name : 'Checkout'
-        uses : 'actions/checkout@v3'
+        uses : 'actions/checkout@v7'
       - name : 'manaakiwhenua-standards'
         uses : manaakiwhenua/manaakiwhenua-standards@v0.2.2
 
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Micromamba (Python + GDAL)
         uses: mamba-org/setup-micromamba@v3.1.0


### PR DESCRIPTION
## Summary
GitHub Actions is deprecating Node.js 20; the `actions/checkout@v3`/`@v4` pins used in both jobs of `main.yml` still bundle it and were being forced onto a Node 24 compatibility shim, visible as a warning annotation on every CI run. Bumped both to v7, which targets Node 24 natively.

## Test plan
- [x] Watched the actual CI run (30408823696) — both jobs green, no deprecation annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)