### PR TITLE
Fail-fast CLI validation for --compression, --threads, --chunksize

### DIFF
--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -1,3 +1,4 @@
+import click
 from unittest import TestCase
 
 from vector2dggs import common
@@ -13,6 +14,54 @@ class TestErrors(TestCase):
     Error-path unit tests that raise before touching the filesystem,
     so no output cleanup is needed.
     """
+
+    def test_invalid_compression_raises(self):
+        with self.assertRaises(click.BadParameter):
+            h3(
+                [
+                    TEST_FILE_PATH,
+                    str(TEST_OUTPUT_PATH),
+                    "--layer",
+                    TEST_LAYER_NAME,
+                    "-r",
+                    "8",
+                    "-cp",
+                    "bogus",
+                ],
+                standalone_mode=False,
+            )
+
+    def test_zero_threads_raises(self):
+        with self.assertRaises(click.BadParameter):
+            h3(
+                [
+                    TEST_FILE_PATH,
+                    str(TEST_OUTPUT_PATH),
+                    "--layer",
+                    TEST_LAYER_NAME,
+                    "-r",
+                    "8",
+                    "-t",
+                    "0",
+                ],
+                standalone_mode=False,
+            )
+
+    def test_negative_chunksize_raises(self):
+        with self.assertRaises(click.BadParameter):
+            h3(
+                [
+                    TEST_FILE_PATH,
+                    str(TEST_OUTPUT_PATH),
+                    "--layer",
+                    TEST_LAYER_NAME,
+                    "-r",
+                    "8",
+                    "-ch",
+                    "-5",
+                ],
+                standalone_mode=False,
+            )
 
     def test_parent_res_not_less_than_resolution_raises(self):
         with self.assertRaises(common.ParentResolutionException):

--- a/tests/classes/output_validation.py
+++ b/tests/classes/output_validation.py
@@ -83,14 +83,3 @@ class TestOutputValidation(TestRunthrough):
         table = pq.read_table(self._parquet_files()[0])
         self.assertIn("Name_2018", table.schema.names)
         self.assertIn("LCDB_UID", table.schema.names)
-
-    def test_zero_threads_does_not_crash(self):
-        """--threads 0 (e.g. from a single-core cpu_count()-1 default) must not
-        crash ProcessPoolExecutor; it should be floored to at least 1 worker."""
-        self._run_h3(("-t", "0"))
-        self._parquet_files()
-
-    def test_negative_threads_does_not_crash(self):
-        """A negative --threads value should likewise be floored to 1 worker."""
-        self._run_h3(("-t", "-1"))
-        self._parquet_files()

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -60,7 +60,7 @@ def make_dggs_command(
         "-ch",
         "--chunksize",
         required=True,
-        type=int,
+        type=click.IntRange(min=1),
         default=const.DEFAULTS["ch"],
         help="The number of rows per index partition to use when spatially partitioning. Adjusting this number will trade off memory use and time.",
         nargs=1,
@@ -95,7 +95,7 @@ def make_dggs_command(
         "--threads",
         required=False,
         default=const.DEFAULTS["t"],
-        type=int,
+        type=click.IntRange(min=1),
         help="Amount of threads used for operation",
         nargs=1,
     )
@@ -105,6 +105,7 @@ def make_dggs_command(
         required=False,
         default=const.DEFAULTS["cp"],
         type=str,
+        callback=common.validate_compression,
         help="Compression method to use for the output Parquet files. Options include 'snappy', 'gzip', 'brotli', 'lz4', 'zstd', etc. Use 'none' for no compression.",
         nargs=1,
     )

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -3,6 +3,7 @@ import errno
 import json
 import logging
 import tempfile
+import click
 import click_log
 import sqlalchemy
 import shutil
@@ -71,6 +72,22 @@ def check_compaction_requirements(compact: bool, id_field: Union[str, None]) -> 
         raise IdFieldError(
             "An id_field is required for compaction, in order to handle the potential for overlapping features"
         )
+
+
+def validate_compression(ctx, param, value: str) -> str:
+    """
+    Click callback that fails fast on an unsupported Parquet compression
+    codec, by asking pyarrow directly (an in-memory, zero-row write) rather
+    than maintaining a hardcoded codec list that could drift from what the
+    installed pyarrow actually supports.
+    """
+    try:
+        pq.write_table(pa.table({"_": [0]}), pa.BufferOutputStream(), compression=value)
+    except Exception as e:
+        raise click.BadParameter(
+            f"'{value}' is not a supported Parquet compression codec: {e}"
+        )
+    return value
 
 
 def db_conn_and_input_path(


### PR DESCRIPTION
## Summary
- `--compression` was passed straight through to `pyarrow.parquet.write_to_dataset`/`to_parquet` with no upfront validation — a typo only surfaced as an error after the read/bisect/spatial-partition stages had already run on potentially large input.
- `--threads`/`--chunksize` accepted any `int` with no lower-bound validation.

`validate_compression` (a click callback in `common.py`) validates by asking pyarrow directly — a trivial in-memory zero-row Parquet write — rather than hardcoding a codec list that could drift from what the installed pyarrow build actually supports. `--threads`/`--chunksize` now use `click.IntRange(min=1)`.

Note: this supersedes the #80 defensive floor at the CLI layer — explicit `--threads 0`/negative is now a clear validation error instead of being silently floored to 1. The two tests added for #80 (which asserted silent success on `--threads 0`/`-1`) are replaced here with fail-fast assertions in `TestErrors`, alongside equivalent tests for `--compression`/`--chunksize`. The `max(1, processes)` guards in `common.py` remain untouched as a safety net for direct/library use of `common.index()` outside the CLI.

Closes #87

## Test plan
- [x] Manually confirmed all three (bad compression, `-t 0`, `-ch -5`) fail immediately with a clean error, before any file I/O
- [x] Manually confirmed valid values (`-cp zstd -t 2 -ch 10`) still work end-to-end
- [x] `black --check` passes
- [x] Full test suite passes (135/135)

🤖 Generated with [Claude Code](https://claude.com/claude-code)