### PR TITLE
Audit follow-up: exception chaining, ruff bugbear rules, README Docker note

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ Please run `black .`, `ruff check .` and `mypy vector2dggs/` before committing. 
 
 #### Tests
 
-Tests are included. To run them, activate the Poetry environment first (`eval "$(poetry env activate)"`), then run:
+Tests are included. Some tests (covering the PostgreSQL/PostGIS input path) spin up a throwaway PostGIS container via Docker; they'll be skipped automatically if Docker isn't available, rather than failing the run.
+
+To run them, activate the Poetry environment first (`eval "$(poetry env activate)"`), then run:
 
 ```bash
 python tests/test_vector2dggs.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ line-length = 88
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "B"]
 ignore = ["E501"]  # line length is black's job
 
 [tool.mypy]

--- a/tests/classes/postgis.py
+++ b/tests/classes/postgis.py
@@ -28,13 +28,15 @@ class TestPostGIS(TestRunthrough):
         try:
             from testcontainers.community.postgres import PostgresContainer
         except Exception as e:
-            raise unittest.SkipTest(f"testcontainers not available: {e}")
+            raise unittest.SkipTest(f"testcontainers not available: {e}") from e
 
         try:
             cls.pg = PostgresContainer("postgis/postgis:16-3.4")
             cls.pg.start()
         except Exception as e:
-            raise unittest.SkipTest(f"Docker unavailable, skipping PostGIS tests: {e}")
+            raise unittest.SkipTest(
+                f"Docker unavailable, skipping PostGIS tests: {e}"
+            ) from e
 
         cls.connection_url = cls.pg.get_connection_url()
         engine = sqlalchemy.create_engine(cls.connection_url)

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -89,7 +89,7 @@ def validate_compression(ctx, param, value: str) -> str:
     except Exception as e:
         raise click.BadParameter(
             f"'{value}' is not a supported Parquet compression codec: {e}"
-        )
+        ) from e
     return value
 
 


### PR DESCRIPTION
## Summary

Small follow-up from another audit pass against the codebase (post #80-#98):

1. **Exception chaining**: `validate_compression`'s `raise click.BadParameter(...)` dropped the original exception (no `from e`). Fixed.
2. **Ruff bugbear rules**: added `"B"` to `[tool.ruff.lint] select` — this immediately caught two more instances of the identical missing-`from e` pattern in `tests/classes/postgis.py`'s `setUpClass`. Fixed both.
3. **README**: the Tests section didn't mention that the PostGIS tests need Docker and skip (not fail) without it — could confuse a contributor who doesn't read the test file.

Closes #99

## Test plan
- [x] Watched the actual CI run (30416870799) — ruff (with the new bugbear rule), black, mypy, and the full test suite (138/138) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)