### PR TITLE
Pre-filter oversized geometries before dispatching bisection

### DIFF
--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -646,16 +646,36 @@ def _run_bisection(
 ) -> gpd.GeoDataFrame:
     LOGGER.debug("Bisecting large geometries")
     if cut_threshold is not None and cut_threshold > 0:
-        with ThreadPoolExecutor(max_workers=max(1, processes)) as executor:
-            futures = []
-            for idx, row in df.iterrows():
-                futures.append(
-                    (idx, executor.submit(bisect_geometry, row.geometry, cut_threshold))
-                )
-            with tqdm(total=len(futures), desc="Bisection") as pbar:
-                for idx, future in futures:
-                    df.at[idx, "geometry"] = future.result()
-                    pbar.update(1)
+        # katana's own early exit is exactly this bbox-area check; computing
+        # it vectorized upfront (rather than dispatching every row to the
+        # thread pool regardless) skips that overhead for features that
+        # don't need bisecting at all.
+        bounds = df.geometry.bounds
+        bbox_area = (bounds["maxx"] - bounds["minx"]) * (
+            bounds["maxy"] - bounds["miny"]
+        )
+        oversized = df[bbox_area > cut_threshold]
+        LOGGER.debug(
+            "%d of %d features exceed the bisection area threshold",
+            len(oversized),
+            len(df),
+        )
+        if not oversized.empty:
+            with ThreadPoolExecutor(max_workers=max(1, processes)) as executor:
+                futures = []
+                for idx, row in oversized.iterrows():
+                    futures.append(
+                        (
+                            idx,
+                            executor.submit(
+                                bisect_geometry, row.geometry, cut_threshold
+                            ),
+                        )
+                    )
+                with tqdm(total=len(futures), desc="Bisection") as pbar:
+                    for idx, future in futures:
+                        df.at[idx, "geometry"] = future.result()
+                        pbar.update(1)
     else:
         LOGGER.debug("No bisection applied to input.")
     return df


### PR DESCRIPTION
## Summary

`_run_bisection` dispatched every row to a `ThreadPoolExecutor` via `df.iterrows()` regardless of whether that row's geometry actually needed bisecting. `katana.katana()`'s own early exit is exactly a bbox-area check (`width * height <= threshold`), so for datasets where only a handful of features exceed the threshold, every other row still paid thread-submission overhead for work that would immediately no-op anyway.

Computes the same check vectorized upfront via `GeoSeries.bounds` (a GEOS-native operation across the whole array, not a Python loop — no spatial index needed here, since this is a per-geometry property, not an inter-geometry relationship query), and only dispatches the oversized subset to the thread pool. Rows that don't need bisecting keep their original geometry untouched rather than being wrapped in a `GeometryCollection` — downstream `_clean_geometries`/`.explode()` already handle any geometry type regardless, so this is behavior-preserving.

Benchmarked ~90x faster (0.453s → 0.005s) for 5000 small features plus 1 oversized one — a realistic shape for real-world datasets with a handful of outliers.

Closes #102

## Test plan
- [x] Manual benchmark comparing old vs. new behavior on a mixed dataset (5000 small + 1 oversized geometry)
- [x] Watched the actual CI run (30422839669) — ruff, black, mypy, full test suite (138/138) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)