### PR TITLE
Deduplicate polyfill() split/concat boilerplate across indexers

### DIFF
--- a/vector2dggs/indexers/a5vectorindexer.py
+++ b/vector2dggs/indexers/a5vectorindexer.py
@@ -31,39 +31,24 @@ class A5VectorIndexer(VectorIndexer):
             for c in a5.line_string_to_cells(list(geom.coords), resolution)
         ]
 
-    def polyfill(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
-        geom_col = df.geometry.name
-        parts = []
+    def _polyfill_polygons(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
+        return self._geo_to_cells(
+            df, resolution, self._polyfill_polygon, df.geometry.name
+        )
 
-        df_polygon = df[df.geom_type == "Polygon"]
-        if not df_polygon.empty:
-            parts.append(
-                self._geo_to_cells(
-                    df_polygon, resolution, self._polyfill_polygon, geom_col
-                )
-            )
+    def _polyfill_linestrings(
+        self, df: gpd.GeoDataFrame, resolution: int
+    ) -> pd.DataFrame:
+        result = self._geo_to_cells(df, resolution, self._linetrace, df.geometry.name)
+        return result[~result.index.duplicated(keep="first")]
 
-        df_linestring = df[df.geom_type == "LineString"]
-        if not df_linestring.empty:
-            ls = self._geo_to_cells(
-                df_linestring, resolution, self._linetrace, geom_col
-            )
-            parts.append(ls[~ls.index.duplicated(keep="first")])
-
-        df_point = df[df.geom_type == "Point"]
-        if not df_point.empty:
-            parts.append(
-                self._geo_to_cells(
-                    df_point,
-                    resolution,
-                    lambda geom, res: [
-                        a5.u64_to_hex(a5.lonlat_to_cell((geom.x, geom.y), res))
-                    ],
-                    geom_col,
-                )
-            )
-
-        return pd.concat(parts) if parts else pd.DataFrame()
+    def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
+        return self._geo_to_cells(
+            df,
+            resolution,
+            lambda geom, res: [a5.u64_to_hex(a5.lonlat_to_cell((geom.x, geom.y), res))],
+            df.geometry.name,
+        )
 
     def secondary_index(self, df: pd.DataFrame, parent_res: int) -> pd.DataFrame:
         df[f"a5_{parent_res:02}"] = df.index.map(

--- a/vector2dggs/indexers/geohashvectorindexer.py
+++ b/vector2dggs/indexers/geohashvectorindexer.py
@@ -20,63 +20,56 @@ class GeohashVectorIndexer(VectorIndexer):
 
     GEOHASH_BASE32_SET = set("0123456789bcdefghjkmnpqrstuvwxyz")
 
-    def polyfill(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
+    def _polyfill_polygons(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
         geom_col = df.geometry.name
         gh_col = "geohash"
-        parts = []
-
-        df_polygon = df[df.geom_type == "Polygon"].copy()
-        if not df_polygon.empty:
-            result = (
-                df_polygon.assign(
-                    **{
-                        gh_col: df_polygon.geometry.apply(
-                            lambda geom: self._polygon_to_geohashes(geom, level)
-                        )
-                    }
-                )
-                .drop(columns=[geom_col])
-                .explode(gh_col, ignore_index=True)
-                .set_index(gh_col)
+        result = (
+            df.assign(
+                **{
+                    gh_col: df.geometry.apply(
+                        lambda geom: self._polygon_to_geohashes(geom, level)
+                    )
+                }
             )
-            parts.append(pd.DataFrame(result))
+            .drop(columns=[geom_col])
+            .explode(gh_col, ignore_index=True)
+            .set_index(gh_col)
+        )
+        return pd.DataFrame(result)
 
-        df_linestring = df[df.geom_type == "LineString"].copy()
-        if not df_linestring.empty:
-            result = (
-                df_linestring.assign(
-                    **{
-                        gh_col: df_linestring.geometry.apply(
-                            lambda geom: geohash_traversal.linetrace_linewise(
-                                geom, level
-                            )
-                        )
-                    }
-                )
-                .drop(columns=[geom_col])
-                .explode(gh_col, ignore_index=True)
-                .dropna(subset=[gh_col])
-                .set_index(gh_col)
+    def _polyfill_linestrings(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
+        geom_col = df.geometry.name
+        gh_col = "geohash"
+        result = (
+            df.assign(
+                **{
+                    gh_col: df.geometry.apply(
+                        lambda geom: geohash_traversal.linetrace_linewise(geom, level)
+                    )
+                }
             )
-            result = result[~result.index.duplicated(keep="first")]
-            parts.append(pd.DataFrame(result))
+            .drop(columns=[geom_col])
+            .explode(gh_col, ignore_index=True)
+            .dropna(subset=[gh_col])
+            .set_index(gh_col)
+        )
+        return pd.DataFrame(result[~result.index.duplicated(keep="first")])
 
-        df_point = df[df.geom_type == "Point"].copy()
-        if not df_point.empty:
-            result = (
-                df_point.assign(
-                    **{
-                        gh_col: df_point.geometry.apply(
-                            lambda geom: encode(geom.y, geom.x, precision=level)
-                        )
-                    }
-                )
-                .drop(columns=[geom_col])
-                .set_index(gh_col)
+    def _polyfill_points(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
+        geom_col = df.geometry.name
+        gh_col = "geohash"
+        result = (
+            df.assign(
+                **{
+                    gh_col: df.geometry.apply(
+                        lambda geom: encode(geom.y, geom.x, precision=level)
+                    )
+                }
             )
-            parts.append(pd.DataFrame(result))
-
-        return pd.concat(parts) if parts else pd.DataFrame()
+            .drop(columns=[geom_col])
+            .set_index(gh_col)
+        )
+        return pd.DataFrame(result)
 
     def secondary_index(self, df: pd.DataFrame, parent_level: int) -> pd.DataFrame:
         """

--- a/vector2dggs/indexers/h3vectorindexer.py
+++ b/vector2dggs/indexers/h3vectorindexer.py
@@ -27,37 +27,24 @@ class H3VectorIndexer(VectorIndexer):
             cells.update(h3.grid_path_cells(start, end))
         return list(cells)
 
-    def polyfill(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
-        geom_col = df.geometry.name
-        parts = []
+    def _polyfill_polygons(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
+        return self._geo_to_cells(
+            df, resolution, self._polyfill_polygon, df.geometry.name
+        )
 
-        df_polygon = df[df.geom_type == "Polygon"]
-        if not df_polygon.empty:
-            parts.append(
-                self._geo_to_cells(
-                    df_polygon, resolution, self._polyfill_polygon, geom_col
-                )
-            )
+    def _polyfill_linestrings(
+        self, df: gpd.GeoDataFrame, resolution: int
+    ) -> pd.DataFrame:
+        result = self._geo_to_cells(df, resolution, self._linetrace, df.geometry.name)
+        return result[~result.index.duplicated(keep="first")]
 
-        df_linestring = df[df.geom_type == "LineString"]
-        if not df_linestring.empty:
-            ls = self._geo_to_cells(
-                df_linestring, resolution, self._linetrace, geom_col
-            )
-            parts.append(ls[~ls.index.duplicated(keep="first")])
-
-        df_point = df[df.geom_type == "Point"]
-        if not df_point.empty:
-            parts.append(
-                self._geo_to_cells(
-                    df_point,
-                    resolution,
-                    lambda geom, res: [h3.latlng_to_cell(geom.y, geom.x, res)],
-                    geom_col,
-                )
-            )
-
-        return pd.concat(parts) if parts else pd.DataFrame()
+    def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
+        return self._geo_to_cells(
+            df,
+            resolution,
+            lambda geom, res: [h3.latlng_to_cell(geom.y, geom.x, res)],
+            df.geometry.name,
+        )
 
     def secondary_index(self, df: pd.DataFrame, parent_res: int) -> pd.DataFrame:
         df[f"h3_{parent_res:02}"] = df.index.map(

--- a/vector2dggs/indexers/rhpvectorindexer.py
+++ b/vector2dggs/indexers/rhpvectorindexer.py
@@ -25,34 +25,29 @@ class RHPVectorIndexer(VectorIndexer):
 
     GEODESIC_POLYFILL = False
 
-    def polyfill(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
+    def _polyfill_polygons(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
         geom_col = df.geometry.name
-        parts = []
+        result = df.rhp.polyfill_resample(
+            resolution, return_geometry=False, compress=False
+        ).drop(columns=["index", geom_col])
+        return pd.DataFrame(result)
 
-        df_polygon = df[df.geom_type == "Polygon"]
-        if not df_polygon.empty:
-            result = df_polygon.rhp.polyfill_resample(
-                resolution, return_geometry=False, compress=False
-            ).drop(columns=["index", geom_col])
-            parts.append(pd.DataFrame(result))
+    def _polyfill_linestrings(
+        self, df: gpd.GeoDataFrame, resolution: int
+    ) -> pd.DataFrame:
+        geom_col = df.geometry.name
+        result = (
+            df.rhp.linetrace(resolution)
+            .explode(COLUMNS["linetrace"])
+            .set_index(COLUMNS["linetrace"])
+            .drop(columns=[geom_col])
+        )
+        return pd.DataFrame(result[~result.index.duplicated(keep="first")])
 
-        df_linestring = df[df.geom_type == "LineString"]
-        if not df_linestring.empty:
-            result = (
-                df_linestring.rhp.linetrace(resolution)
-                .explode(COLUMNS["linetrace"])
-                .set_index(COLUMNS["linetrace"])
-                .drop(columns=[geom_col])
-            )
-            result = result[~result.index.duplicated(keep="first")]
-            parts.append(pd.DataFrame(result))
-
-        df_point = df[df.geom_type == "Point"]
-        if not df_point.empty:
-            result = df_point.rhp.geo_to_rhp(resolution, set_index=True)
-            parts.append(pd.DataFrame(result.drop(columns=[geom_col])))
-
-        return pd.concat(parts) if parts else pd.DataFrame()
+    def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
+        geom_col = df.geometry.name
+        result = df.rhp.geo_to_rhp(resolution, set_index=True)
+        return pd.DataFrame(result.drop(columns=[geom_col]))
 
     def secondary_index(self, df: pd.DataFrame, parent_res: int) -> pd.DataFrame:
         """

--- a/vector2dggs/indexers/s2vectorindexer.py
+++ b/vector2dggs/indexers/s2vectorindexer.py
@@ -20,41 +20,33 @@ class S2VectorIndexer(VectorIndexer):
 
     GEODESIC_POLYFILL = True
 
-    def polyfill(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
+    def _polyfill_polygons(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
         geom_col = df.geometry.name
-        parts = []
+        result = (
+            self.polyfill_polygons(df.copy(), level)
+            .explode("s2index")
+            .set_index("s2index")
+            .drop(columns=[geom_col])
+        )
+        return pd.DataFrame(result)
 
-        df_polygon = df[df.geom_type == "Polygon"].copy()
-        if not df_polygon.empty:
-            result = (
-                self.polyfill_polygons(df_polygon, level)
-                .explode("s2index")
-                .set_index("s2index")
-                .drop(columns=[geom_col])
-            )
-            parts.append(pd.DataFrame(result))
+    def _polyfill_linestrings(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
+        geom_col = df.geometry.name
+        df = df.copy()
+        df["s2index"] = df.geometry.apply(
+            lambda geom: self.cell_ids_from_linestring(geom, level)
+        )
+        result = df.drop(columns=[geom_col]).explode("s2index").set_index("s2index")
+        return pd.DataFrame(result)
 
-        df_linestring = df[df.geom_type == "LineString"].copy()
-        if not df_linestring.empty:
-            df_linestring["s2index"] = df_linestring.geometry.apply(
-                lambda geom: self.cell_ids_from_linestring(geom, level)
-            )
-            result = (
-                df_linestring.drop(columns=[geom_col])
-                .explode("s2index")
-                .set_index("s2index")
-            )
-            parts.append(pd.DataFrame(result))
-
-        df_point = df[df.geom_type == "Point"].copy()
-        if not df_point.empty:
-            df_point["s2index"] = df_point.geometry.apply(
-                lambda geom: self.cell_id_from_point(geom, level)
-            )
-            result = df_point.drop(columns=[geom_col]).set_index("s2index")
-            parts.append(pd.DataFrame(result))
-
-        return pd.concat(parts) if parts else pd.DataFrame()
+    def _polyfill_points(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
+        geom_col = df.geometry.name
+        df = df.copy()
+        df["s2index"] = df.geometry.apply(
+            lambda geom: self.cell_id_from_point(geom, level)
+        )
+        result = df.drop(columns=[geom_col]).set_index("s2index")
+        return pd.DataFrame(result)
 
     def secondary_index(self, df: pd.DataFrame, parent_level: int) -> pd.DataFrame:
         """

--- a/vector2dggs/indexers/vectorindexer.py
+++ b/vector2dggs/indexers/vectorindexer.py
@@ -21,8 +21,41 @@ class VectorIndexer(ABC):
     def __init__(self, dggs: str):
         self.dggs = dggs
 
+    def polyfill(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
+        """
+        Splits df by geometry type, dispatches each non-empty subset to the
+        corresponding _polyfill_* implementation, and concatenates the results.
+        """
+        parts = []
+
+        df_polygon = df[df.geom_type == "Polygon"]
+        if not df_polygon.empty:
+            parts.append(self._polyfill_polygons(df_polygon, resolution))
+
+        df_linestring = df[df.geom_type == "LineString"]
+        if not df_linestring.empty:
+            parts.append(self._polyfill_linestrings(df_linestring, resolution))
+
+        df_point = df[df.geom_type == "Point"]
+        if not df_point.empty:
+            parts.append(self._polyfill_points(df_point, resolution))
+
+        return pd.concat(parts) if parts else pd.DataFrame()
+
     @abstractmethod
-    def polyfill(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame: ...
+    def _polyfill_polygons(
+        self, df: gpd.GeoDataFrame, resolution: int
+    ) -> pd.DataFrame: ...
+
+    @abstractmethod
+    def _polyfill_linestrings(
+        self, df: gpd.GeoDataFrame, resolution: int
+    ) -> pd.DataFrame: ...
+
+    @abstractmethod
+    def _polyfill_points(
+        self, df: gpd.GeoDataFrame, resolution: int
+    ) -> pd.DataFrame: ...
 
     @abstractmethod
     def secondary_index(self, df: pd.DataFrame, parent_res: int) -> pd.DataFrame: ...


### PR DESCRIPTION
## Summary

Every `VectorIndexer` subclass's `polyfill()` repeated the same split-by-geom-type/empty-check/concat scaffolding, while the actual per-geometry-type cell-generation logic is genuinely different per backend (H3/A5 route through `_geo_to_cells`, S2 has bespoke covering logic, RHP delegates to the `rhppandas` accessor, Geohash has its own edge-cell logic).

This moves the scaffolding into a concrete `VectorIndexer.polyfill()`. Subclasses now implement three smaller methods instead of one monolithic `polyfill()`:

- `_polyfill_polygons(df, resolution) -> pd.DataFrame`
- `_polyfill_linestrings(df, resolution) -> pd.DataFrame`
- `_polyfill_points(df, resolution) -> pd.DataFrame`

No behavior change — the per-backend cell-generation logic is untouched, just relocated.

Closes #104

## Test plan
- [x] `ruff check .` clean
- [x] `black --check .` clean
- [x] `mypy vector2dggs/` clean
- [x] Full test suite: 138 passed
- [x] CI green on the branch before opening this PR