### PR TITLE
Expand ruff lint rules to include pyupgrade, simplify, comprehensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ line-length = 88
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "B"]
+select = ["E", "F", "I", "B", "UP", "SIM", "C4"]
 ignore = ["E501"]  # line length is black's job
 
 [tool.mypy]

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -1,6 +1,5 @@
 import tempfile
 from pathlib import Path
-from typing import Optional, Union
 
 import click
 import click_log
@@ -150,8 +149,8 @@ def make_dggs_command(
     @click.option("-o", "--overwrite", is_flag=True)
     @click.version_option(version=__version__)
     def command(
-        vector_input: Union[str, Path],
-        output_directory: Union[str, Path],
+        vector_input: str | Path,
+        output_directory: str | Path,
         resolution: str,
         parent_res: str,
         id_field: str,
@@ -165,7 +164,7 @@ def make_dggs_command(
         layer: str,
         geom_col: str,
         geo: str,
-        tempdir: Union[str, Path],
+        tempdir: str | Path,
         compact: bool,
         overwrite: bool,
     ):
@@ -180,7 +179,7 @@ def make_dggs_command(
         con, vector_input = common.db_conn_and_input_path(vector_input)
         output_directory = common.resolve_output_path(output_directory, overwrite)
 
-        cut_crs_obj: Optional[pyproj.CRS] = None
+        cut_crs_obj: pyproj.CRS | None = None
         if cut_crs is not None:
             cut_crs_obj = pyproj.CRS.from_user_input(cut_crs)
 

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -7,7 +7,6 @@ import tempfile
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from pathlib import Path, PurePath
 from types import ModuleType
-from typing import Optional, Union  # , Callable
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -36,7 +35,7 @@ from vector2dggs.indexers.vectorindexer import VectorIndexer
 
 from . import katana
 
-resource: Optional[ModuleType]
+resource: ModuleType | None
 try:
     import resource
 except ImportError:  # resource is POSIX-only
@@ -47,7 +46,7 @@ SQLConnectionType = sqlalchemy.engine.Engine
 
 LOGGER = logging.getLogger(__name__)
 click_log.basic_config(LOGGER)
-click_log.ColorFormatter.colors["info"] = dict(fg="green")
+click_log.ColorFormatter.colors["info"] = {"fg": "green"}
 
 
 class ParentResolutionException(Exception):
@@ -60,18 +59,14 @@ class IdFieldError(ValueError):
     pass
 
 
-def check_resolutions(
-    resolution: Union[str, int], parent_res: Union[None, str, int]
-) -> None:
+def check_resolutions(resolution: str | int, parent_res: None | str | int) -> None:
     if parent_res is not None and not int(parent_res) < int(resolution):
         raise ParentResolutionException(
-            "Parent resolution ({pr}) must be less than target resolution ({r})".format(
-                pr=parent_res, r=resolution
-            )
+            f"Parent resolution ({parent_res}) must be less than target resolution ({resolution})"
         )
 
 
-def check_compaction_requirements(compact: bool, id_field: Union[str, None]) -> None:
+def check_compaction_requirements(compact: bool, id_field: str | None) -> None:
     if compact and not id_field:
         raise IdFieldError(
             "An id_field is required for compaction, in order to handle the potential for overlapping features"
@@ -95,9 +90,9 @@ def validate_compression(ctx, param, value: str) -> str:
 
 
 def db_conn_and_input_path(
-    vector_input: Union[str, Path],
-) -> tuple[Optional[SQLConnectionType], Union[str, Path]]:
-    con: Optional[SQLConnectionType] = None
+    vector_input: str | Path,
+) -> tuple[SQLConnectionType | None, str | Path]:
+    con: SQLConnectionType | None = None
     scheme: str = urlparse(str(vector_input)).scheme
 
     if bool(scheme) and scheme != "file":
@@ -120,9 +115,7 @@ def db_conn_and_input_path(
     return (con, vector_input)
 
 
-def resolve_output_path(
-    output_directory: Union[str, Path], overwrite: bool
-) -> Union[str, Path]:
+def resolve_output_path(output_directory: str | Path, overwrite: bool) -> str | Path:
     output_directory = Path(output_directory)
     outputexists = os.path.exists(output_directory)
 
@@ -161,9 +154,7 @@ def drop_condition(
     return df
 
 
-def get_parent_res(
-    dggs: str, parent_res: Union[None, str, int], resolution: int
-) -> int:
+def get_parent_res(dggs: str, parent_res: None | str | int, resolution: int) -> int:
     """
     Uses a parent resolution,
     OR,
@@ -171,7 +162,7 @@ def get_parent_res(
 
     Used for intermediate re-partioning.
     """
-    if dggs not in const.DEFAULT_DGGS_PARENT_RES.keys():
+    if dggs not in const.DEFAULT_DGGS_PARENT_RES:
         raise RuntimeError(
             "Unknown dggs {dggs}) -  must be one of [ {options} ]".format(
                 dggs=dggs, options=", ".join(const.DEFAULT_DGGS_PARENT_RES.keys())
@@ -398,10 +389,10 @@ def _merge_partition_files(partition_dir: Path, compression: str) -> None:
 def _parent_partitioning(
     indexer: VectorIndexer,
     input_dir: Path,
-    output_dir: Union[Path, str],
+    output_dir: Path | str,
     resolution: int,
     parent_res: int,
-    id_field: Optional[str],
+    id_field: str | None,
     compact: bool,
     geo: str,
     **kwargs,
@@ -539,9 +530,9 @@ def bisection_preparation(
     df: pd.DataFrame,
     dggs: str,
     parent_res: int,
-    cut_crs: Optional[pyproj.CRS] = None,
-    cut_threshold: Union[None, float] = None,
-) -> tuple[pd.DataFrame, pyproj.CRS, Union[None, float]]:
+    cut_crs: pyproj.CRS | None = None,
+    cut_threshold: None | float = None,
+) -> tuple[pd.DataFrame, pyproj.CRS, None | float]:
     cut_threshold = float(cut_threshold) if cut_threshold is not None else None
 
     if cut_threshold and cut_crs:
@@ -593,11 +584,11 @@ def bisect_geometry(geometry, cut_threshold):
 
 
 def _read_input(
-    input_file: Union[Path, str],
-    layer: Optional[str],
-    con: Optional[SQLConnectionType],
+    input_file: Path | str,
+    layer: str | None,
+    con: SQLConnectionType | None,
     keep_attributes: bool,
-    id_field: Optional[str],
+    id_field: str | None,
     geom_col: str,
 ) -> gpd.GeoDataFrame:
     if layer and con:
@@ -627,7 +618,7 @@ def _read_input(
 
 def _prepare_dataframe(
     df: gpd.GeoDataFrame,
-    id_field: Optional[str],
+    id_field: str | None,
     keep_attributes: bool,
 ) -> gpd.GeoDataFrame:
     if id_field:
@@ -642,7 +633,7 @@ def _prepare_dataframe(
 
 def _run_bisection(
     df: gpd.GeoDataFrame,
-    cut_threshold: Union[None, float],
+    cut_threshold: None | float,
     processes: int,
 ) -> gpd.GeoDataFrame:
     LOGGER.debug("Bisecting large geometries")
@@ -788,25 +779,25 @@ def _run_dggs_indexing(
 
 def index(
     dggs: str,
-    input_file: Union[Path, str],
-    output_directory: Union[Path, str],
+    input_file: Path | str,
+    output_directory: Path | str,
     resolution: int,
-    parent_res: Union[None, str, int],
+    parent_res: None | str | int,
     keep_attributes: bool,
     chunksize: int,
     spatial_sorting: str,
-    cut_threshold: Union[None, float],
+    cut_threshold: None | float,
     processes: int,
     compression: str = "snappy",
-    id_field: Optional[str] = None,
-    cut_crs: Optional[pyproj.CRS] = None,
-    con: Optional[SQLConnectionType] = None,
-    layer: Optional[str] = None,
+    id_field: str | None = None,
+    cut_crs: pyproj.CRS | None = None,
+    con: SQLConnectionType | None = None,
+    layer: str | None = None,
     geom_col: str = "geom",
     geo: str = const.GeoOutputMode.NONE.value,
     overwrite: bool = False,
     compact: bool = True,
-) -> Union[Path, str]:
+) -> Path | str:
     """
     Performs multi-threaded DGGS indexing on geometries (including multipart and collections).
     """

--- a/vector2dggs/indexerfactory.py
+++ b/vector2dggs/indexerfactory.py
@@ -1,9 +1,8 @@
 from importlib import import_module
-from typing import Dict, Tuple, Type
 
 from vector2dggs.indexers import vectorindexer
 
-INDEXER_LOOKUP: Dict[str, Tuple[str, str]] = {
+INDEXER_LOOKUP: dict[str, tuple[str, str]] = {
     "h3": ("vector2dggs.indexers.h3vectorindexer", "H3VectorIndexer"),
     "rhp": ("vector2dggs.indexers.rhpvectorindexer", "RHPVectorIndexer"),
     "geohash": ("vector2dggs.indexers.geohashvectorindexer", "GeohashVectorIndexer"),
@@ -28,5 +27,5 @@ def indexer_instance(dggs: str) -> vectorindexer.VectorIndexer:
             f"Install optional dependencies: pip install 'vector2dggs[{dggs}]' "
             f"(or 'vector2dggs[all]')."
         ) from e
-    indexer: Type[vectorindexer.VectorIndexer] = getattr(module, class_name)
+    indexer: type[vectorindexer.VectorIndexer] = getattr(module, class_name)
     return indexer(dggs)

--- a/vector2dggs/indexers/geohash/traversal.py
+++ b/vector2dggs/indexers/geohash/traversal.py
@@ -10,7 +10,6 @@ characters, 1-12).
 """
 
 import math
-from typing import Optional
 
 from geohash import decode, encode, neighbors
 from shapely.geometry import LineString
@@ -59,19 +58,19 @@ def path_cells_linewise(
         return 1.0 + w * line.distance(Point(lng, lat))
 
     g_fwd = {start: 0.0}
-    came_from_fwd: dict[str, Optional[str]] = {start: None}
+    came_from_fwd: dict[str, str | None] = {start: None}
     heap_fwd = [(h_fwd(start), start)]
 
     g_bwd = {end: 0.0}
-    came_from_bwd: dict[str, Optional[str]] = {end: None}
+    came_from_bwd: dict[str, str | None] = {end: None}
     heap_bwd = [(h_bwd(end), end)]
 
     best_cost = math.inf
-    meeting_cell: Optional[str] = None
+    meeting_cell: str | None = None
 
     def reconstruct(cell: str) -> set[str]:
         path = set()
-        node: Optional[str] = cell
+        node: str | None = cell
         while node is not None:
             path.add(node)
             node = came_from_fwd[node]

--- a/vector2dggs/indexers/geohashvectorindexer.py
+++ b/vector2dggs/indexers/geohashvectorindexer.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterable
 from itertools import product
-from typing import Iterable
 
 import geopandas as gpd
 import pandas as pd

--- a/vector2dggs/indexers/rhpvectorindexer.py
+++ b/vector2dggs/indexers/rhpvectorindexer.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterable
 from itertools import product
-from typing import Iterable
 
 import geopandas as gpd
 import pandas as pd

--- a/vector2dggs/indexers/s2vectorindexer.py
+++ b/vector2dggs/indexers/s2vectorindexer.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterable
 from math import ceil
-from typing import Iterable, Union
 
 import geopandas as gpd
 import pandas as pd
@@ -157,7 +157,7 @@ class S2VectorIndexer(VectorIndexer):
         return df
 
     def max_cells_for_geom(
-        self, geom: Union[Polygon, LineString], level: int, margin: float = 1.02
+        self, geom: Polygon | LineString, level: int, margin: float = 1.02
     ) -> int:
         """
         Calculate the maximum number of S2 cells that are appropriate for the given geometry and level.
@@ -173,8 +173,8 @@ class S2VectorIndexer(VectorIndexer):
     def bbox_area_in_m2(
         self,
         geom: Polygon,
-        src_crs: Union[str, CRS] = "EPSG:4326",
-        dst_crs: Union[str, CRS] = "EPSG:6933",
+        src_crs: str | CRS = "EPSG:4326",
+        dst_crs: str | CRS = "EPSG:6933",
     ) -> float:
         """
         Calculate the area of the bounding box of a geometry in square meters.

--- a/vector2dggs/indexers/vectorindexer.py
+++ b/vector2dggs/indexers/vectorindexer.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Iterable
+from collections.abc import Callable, Iterable
 from uuid import uuid4
 
 import geopandas as gpd
@@ -159,11 +159,11 @@ class VectorIndexer(ABC):
 
         uncompressable = {
             id: feature_cell_groups[id] & feature_cell_compact[id]
-            for id in feature_cell_groups.keys()
+            for id in feature_cell_groups
         }
         compressable = {
             id: feature_cell_compact[id] - feature_cell_groups[id]
-            for id in feature_cell_groups.keys()
+            for id in feature_cell_groups
         }
 
         # Get rows that cannot be compressed

--- a/vector2dggs/katana.py
+++ b/vector2dggs/katana.py
@@ -11,8 +11,6 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-from typing import List, Union
-
 from shapely import force_2d, has_m, has_z
 from shapely.geometry import (
     GeometryCollection,
@@ -28,12 +26,12 @@ from shapely.validation import make_valid
 
 
 def katana(
-    geometry: Union[BaseGeometry, None],
+    geometry: BaseGeometry | None,
     threshold: float,
     count: int = 0,
     max_recursion_depth: int = 250,
     check_2D: bool = True,
-) -> List[BaseGeometry]:
+) -> list[BaseGeometry]:
     """
     Recursively split a geometry into two parts across its shortest dimension.
     Invalid input `geometry` will silently be made valid (if possible).
@@ -68,7 +66,7 @@ def katana(
         a = box(bounds[0], bounds[1], bounds[0] + width / 2, bounds[3])
         b = box(bounds[0] + width / 2, bounds[1], bounds[2], bounds[3])
     # Add additional vertices to help prevent indexing errors from use of EPSG:4386 later under the presence of long edges
-    a, b = map(lambda g: g.segmentize(min(width, height) / 4), [a, b])
+    a, b = (g.segmentize(min(width, height) / 4) for g in (a, b))
     result = []
     for d in (
         a,


### PR DESCRIPTION
## Summary

Adds `UP` (pyupgrade), `SIM` (flake8-simplify), `C4` (flake8-comprehensions) to the ruff `select` list (previously `E, F, I, B`), and applies the resulting fixes:

- `Union[X, Y]` / `Optional[X]` → `X | Y` / `X | None`
- `typing.List`/`Dict`/`Tuple` → `list`/`dict`/`tuple`
- `typing.Iterable`/`Callable` → `collections.abc`
- `dict.keys()` membership checks → plain `in dict`
- `dict(fg="green")` → `{"fg": "green"}`
- one `map()` call rewritten as a generator expression

No behavior change — purely mechanical modernization.

Closes #106

## Test plan
- [x] `ruff check .` clean
- [x] `black --check .` clean
- [x] `mypy vector2dggs/` clean
- [x] Full test suite: 141 passed
- [x] CI green on the branch before opening this PR