### PR TITLE
Fix katana recursion depth being capped at 1

### DIFF
--- a/tests/classes/katana.py
+++ b/tests/classes/katana.py
@@ -1,4 +1,5 @@
 from shapely import wkt
+from shapely.geometry import Polygon
 
 from vector2dggs.katana import katana
 
@@ -30,3 +31,13 @@ class TestKatana(TestRunthrough):
         area_threshold = 0.05
         for geom in [polygon_a, polygon_b, polygon_c, polygon_d]:
             katana(geom, area_threshold)
+
+    def test_katana_respects_threshold(self):
+        square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+        threshold = 10.0
+        parts = katana(square, threshold)
+        for part in parts:
+            minx, miny, maxx, maxy = part.bounds
+            self.assertLessEqual((maxx - minx) * (maxy - miny), threshold)
+        # No area may be lost or duplicated by the splitting
+        self.assertAlmostEqual(sum(p.area for p in parts), square.area, places=6)

--- a/vector2dggs/katana.py
+++ b/vector2dggs/katana.py
@@ -79,6 +79,14 @@ def katana(
             if isinstance(
                 e, (Polygon, MultiPolygon, LineString, MultiLineString, LinearRing)
             ):
-                result.extend(katana(e, threshold, count + 1, check_2D))
+                result.extend(
+                    katana(
+                        e,
+                        threshold,
+                        count + 1,
+                        max_recursion_depth=max_recursion_depth,
+                        check_2D=check_2D,
+                    )
+                )
 
     return result


### PR DESCRIPTION
Fixes #108.

`katana()`'s recursive call passed `check_2D` positionally into the `max_recursion_depth` slot, so recursion ran with `max_recursion_depth=True` (== 1) and every geometry was bisected at most once — `-c/--cut_threshold` did almost nothing.

**Fix:** pass `max_recursion_depth` and `check_2D` by keyword in the recursive call.

**Test:** new `test_katana_respects_threshold` — a 100×100 square cut with threshold 10 must produce pieces whose bbox area is ≤ 10, with total area preserved. Written first and confirmed failing (pieces had bbox area 5000) before the fix; passes after.

Note: the pre-existing `test_katana` smoke test now takes ~20s instead of ~0.1s, because recursion actually recurses to its 0.05 threshold now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)