### PR TITLE
Fix bisection corrupting geometries under duplicate id_field values

### DIFF
--- a/tests/classes/bisection.py
+++ b/tests/classes/bisection.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+
+import geopandas as gpd
+from shapely.geometry import Polygon
+
+from vector2dggs.common import _run_bisection
+
+
+class TestBisection(TestCase):
+    """
+    _run_bisection operates on a dataframe indexed by id_field, which is not
+    guaranteed to be unique. Results must be written back to the row they were
+    computed for, not to every row sharing an index label.
+    """
+
+    def test_duplicate_index_labels_do_not_cross_contaminate(self):
+        big = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+        small = Polygon([(20, 20), (20.1, 20), (20.1, 20.1), (20, 20.1)])
+        df = gpd.GeoDataFrame({"geometry": [big, small]}, index=["a", "a"], crs=2193)
+        df.index.name = "id"
+
+        result = _run_bisection(df.copy(), 5.0, 1)
+
+        # Only `big` exceeds the threshold and is bisected; its pieces must
+        # preserve its area
+        self.assertAlmostEqual(result.geometry.iloc[0].area, big.area, places=6)
+        # `small` is under the threshold and must pass through untouched -
+        # not be overwritten with big's bisection result
+        self.assertAlmostEqual(result.geometry.iloc[1].area, small.area, places=9)
+
+    def test_all_oversized_duplicate_labels_each_keep_own_geometry(self):
+        square_a = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+        square_b = Polygon([(100, 100), (110, 100), (110, 110), (100, 110)])
+        df = gpd.GeoDataFrame(
+            {"geometry": [square_a, square_b]}, index=["a", "a"], crs=2193
+        )
+        df.index.name = "id"
+
+        result = _run_bisection(df.copy(), 5.0, 1)
+
+        self.assertAlmostEqual(result.geometry.iloc[0].area, square_a.area, places=6)
+        self.assertAlmostEqual(result.geometry.iloc[1].area, square_b.area, places=6)
+        # The two rows were bisected independently and must not be identical
+        self.assertFalse(result.geometry.iloc[0].equals(result.geometry.iloc[1]))

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -1,5 +1,6 @@
 from .classes.a5 import TestA5 as TestA5
 from .classes.antimeridian import TestAntimeridian as TestAntimeridian
+from .classes.bisection import TestBisection as TestBisection
 from .classes.compaction import TestA5CompactionBounds as TestA5CompactionBounds
 from .classes.compaction import (
     TestGeohashCompactionBounds as TestGeohashCompactionBounds,

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -646,27 +646,31 @@ def _run_bisection(
         bbox_area = (bounds["maxx"] - bounds["minx"]) * (
             bounds["maxy"] - bounds["miny"]
         )
-        oversized = df[bbox_area > cut_threshold]
+        # Positions (not index labels) of oversized rows: the index is the
+        # user-supplied id_field, which is not guaranteed to be unique, and
+        # label-based assignment would write one feature's result into every
+        # row sharing that label.
+        oversized_positions = np.flatnonzero(bbox_area > cut_threshold)
         LOGGER.debug(
             "%d of %d features exceed the bisection area threshold",
-            len(oversized),
+            len(oversized_positions),
             len(df),
         )
-        if not oversized.empty:
+        if len(oversized_positions):
+            geometry_loc = df.columns.get_loc("geometry")
             with ThreadPoolExecutor(max_workers=max(1, processes)) as executor:
-                futures = []
-                for idx, row in oversized.iterrows():
-                    futures.append(
-                        (
-                            idx,
-                            executor.submit(
-                                bisect_geometry, row.geometry, cut_threshold
-                            ),
-                        )
+                futures = [
+                    (
+                        pos,
+                        executor.submit(
+                            bisect_geometry, df.geometry.iloc[pos], cut_threshold
+                        ),
                     )
+                    for pos in oversized_positions
+                ]
                 with tqdm(total=len(futures), desc="Bisection") as pbar:
-                    for idx, future in futures:
-                        df.at[idx, "geometry"] = future.result()
+                    for pos, future in futures:
+                        df.iloc[pos, geometry_loc] = future.result()
                         pbar.update(1)
     else:
         LOGGER.debug("No bisection applied to input.")


### PR DESCRIPTION
Fixes #110.

`_run_bisection` wrote results back by index label (`df.at[idx, "geometry"]`) while the dataframe is indexed by the user-supplied `id_field` — with a duplicated ID, one feature's bisection result silently overwrote every row sharing that label.

**Fix:** select oversized rows and write results back by *position* (`np.flatnonzero` + `df.iloc`), so each row gets exactly its own result regardless of label uniqueness.

**Tests:** new `tests/classes/bisection.py`, written first and confirmed failing:
- mixed case — an under-threshold feature sharing a label with an oversized one passes through untouched
- all-oversized case — two oversized features sharing a label each keep their own (distinct) bisection result

Antimeridian tests (which run `_run_bisection` in the full pipeline) and the h3 runthroughs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)