### PR TITLE
Fix incomplete compaction across dask partitions (visible seams)

### DIFF
--- a/tests/classes/compaction_pipeline.py
+++ b/tests/classes/compaction_pipeline.py
@@ -41,8 +41,7 @@ class TestCompactionAcrossPartitions(TestRunthrough):
     """
 
     def test_compaction_merges_siblings_across_dask_partitions(self):
-        # A small cut threshold fragments features into many rows, and a
-        # small chunksize spreads those rows across many dask partitions.
+        # small -c and -ch scatter each feature across many partitions
         h3(
             [
                 TEST_FILE_PATH,
@@ -69,9 +68,7 @@ class TestCompactionAcrossPartitions(TestRunthrough):
         for cell, feature_id in set(zip(df.index, df["LCDB_UID"], strict=True)):
             cells_by_feature.setdefault(feature_id, set()).add(cell)
 
-        # A complete set of 7 sibling cells (all children of one parent, at
-        # any resolution finer than the parent_res floor) present for a
-        # single feature should have been compacted into that parent.
+        # all 7 children present for one feature => should have been compacted
         unmerged_septets = 0
         for cells in cells_by_feature.values():
             parents = Counter(

--- a/tests/classes/compaction_pipeline.py
+++ b/tests/classes/compaction_pipeline.py
@@ -66,7 +66,7 @@ class TestCompactionAcrossPartitions(TestRunthrough):
 
         df = pd.read_parquet(TEST_OUTPUT_PATH)
         cells_by_feature: dict[str, set[str]] = {}
-        for cell, feature_id in set(zip(df.index, df["LCDB_UID"])):
+        for cell, feature_id in set(zip(df.index, df["LCDB_UID"], strict=True)):
             cells_by_feature.setdefault(feature_id, set()).add(cell)
 
         # A complete set of 7 sibling cells (all children of one parent, at

--- a/tests/classes/compaction_pipeline.py
+++ b/tests/classes/compaction_pipeline.py
@@ -1,0 +1,89 @@
+from collections import Counter
+from unittest import TestCase
+
+import h3 as h3lib
+import pandas as pd
+
+from vector2dggs.h3 import h3
+from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer
+
+from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME, TEST_OUTPUT_PATH
+from .base import TestRunthrough
+
+
+class TestCompactionEmptyPartition(TestCase):
+    """
+    Compaction receives one dataframe per dask partition, and a partition may
+    be empty (e.g. after a shuffle). It must return an empty frame of the
+    expected shape rather than raising.
+    """
+
+    def test_empty_partition_compacts_to_empty(self):
+        df = pd.DataFrame(
+            {"h3_11": [], "LCDB_UID": [], "h3_08": []},
+        )
+        indexer = H3VectorIndexer(dggs="h3")
+        result = indexer.compaction(
+            df, 11, ["LCDB_UID", "h3_08"], "h3_11", "LCDB_UID", 8
+        )
+        self.assertEqual(len(result), 0)
+        self.assertEqual(result.columns.tolist(), ["LCDB_UID", "h3_08"])
+        self.assertEqual(result.index.name, "h3_11")
+
+
+class TestCompactionAcrossPartitions(TestRunthrough):
+    """
+    Compaction must produce the same result regardless of how features are
+    fragmented across dask partitions: any set of sibling cells belonging to
+    one feature that could merge into their parent (down to the parent_res
+    floor) must be merged, even when bisection and chunking scatter the
+    feature's rows over many partitions.
+    """
+
+    def test_compaction_merges_siblings_across_dask_partitions(self):
+        # A small cut threshold fragments features into many rows, and a
+        # small chunksize spreads those rows across many dask partitions.
+        h3(
+            [
+                TEST_FILE_PATH,
+                str(TEST_OUTPUT_PATH),
+                "--layer",
+                TEST_LAYER_NAME,
+                "-r",
+                "11",
+                "-pr",
+                "8",
+                "-id",
+                "LCDB_UID",
+                "-c",
+                "50000",
+                "-ch",
+                "10",
+                "-co",
+            ],
+            standalone_mode=False,
+        )
+
+        df = pd.read_parquet(TEST_OUTPUT_PATH)
+        cells_by_feature: dict[str, set[str]] = {}
+        for cell, feature_id in set(zip(df.index, df["LCDB_UID"])):
+            cells_by_feature.setdefault(feature_id, set()).add(cell)
+
+        # A complete set of 7 sibling cells (all children of one parent, at
+        # any resolution finer than the parent_res floor) present for a
+        # single feature should have been compacted into that parent.
+        unmerged_septets = 0
+        for cells in cells_by_feature.values():
+            parents = Counter(
+                h3lib.cell_to_parent(cell, h3lib.get_resolution(cell) - 1)
+                for cell in cells
+                if h3lib.get_resolution(cell) > 8
+            )
+            unmerged_septets += sum(1 for n in parents.values() if n == 7)
+
+        self.assertEqual(
+            unmerged_septets,
+            0,
+            f"{unmerged_septets} complete sibling sets were left uncompacted "
+            "(feature cells split across dask partitions?)",
+        )

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -8,6 +8,9 @@ from .classes.compaction import (
 from .classes.compaction import TestH3CompactionBounds as TestH3CompactionBounds
 from .classes.compaction import TestRHPCompactionBounds as TestRHPCompactionBounds
 from .classes.compaction import TestS2CompactionBounds as TestS2CompactionBounds
+from .classes.compaction_pipeline import (
+    TestCompactionAcrossPartitions as TestCompactionAcrossPartitions,
+)
 from .classes.errors import TestErrors as TestErrors
 from .classes.errors import TestOverwriteRequired as TestOverwriteRequired
 from .classes.geohash import TestGeohash as TestGeohash

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -409,10 +409,17 @@ def _parent_partitioning(
     ):
 
         if compact:
-            # Compact by spatial partitions (not cell parent partitions; that repartition occurs at pq.write_to_dataset time)
+            # Shuffle so that all rows sharing a parent cell are in the same
+            # dask partition before compacting. Compaction is applied per
+            # partition, and the parent_res floor means sibling cells can only
+            # ever merge within one parent cell - so co-locating rows by the
+            # parent cell column makes per-partition compaction globally
+            # correct, no matter how bisection and chunking have fragmented a
+            # feature's rows across partitions.
             ddf = (
                 ddf.reset_index(drop=False)
                 .dropna(subset=[partition_col])
+                .shuffle(on=partition_col)
                 .map_partitions(
                     indexer.compaction,
                     resolution,

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -409,13 +409,9 @@ def _parent_partitioning(
     ):
 
         if compact:
-            # Shuffle so that all rows sharing a parent cell are in the same
-            # dask partition before compacting. Compaction is applied per
-            # partition, and the parent_res floor means sibling cells can only
-            # ever merge within one parent cell - so co-locating rows by the
-            # parent cell column makes per-partition compaction globally
-            # correct, no matter how bisection and chunking have fragmented a
-            # feature's rows across partitions.
+            # Shuffle by parent cell first: compaction is per-partition, and
+            # the parent_res floor means siblings can only merge within one
+            # parent cell.
             ddf = (
                 ddf.reset_index(drop=False)
                 .dropna(subset=[partition_col])

--- a/vector2dggs/indexers/vectorindexer.py
+++ b/vector2dggs/indexers/vectorindexer.py
@@ -144,10 +144,8 @@ class VectorIndexer(ABC):
         df = df.reset_index(drop=False)
 
         if df.empty:
-            # A dask partition can be empty (e.g. after a shuffle); return an
-            # empty frame of the expected shape. (Also avoids a pandas trap:
-            # an all-False mask built from an empty list has object dtype, so
-            # df[mask] would select columns rather than filter rows.)
+            # e.g. an empty partition after a shuffle; the mask logic below
+            # misbehaves on empty frames (object-dtype mask)
             return df.set_index(dggs_col)[col_order]
 
         feature_cell_groups = (

--- a/vector2dggs/indexers/vectorindexer.py
+++ b/vector2dggs/indexers/vectorindexer.py
@@ -143,6 +143,13 @@ class VectorIndexer(ABC):
         """
         df = df.reset_index(drop=False)
 
+        if df.empty:
+            # A dask partition can be empty (e.g. after a shuffle); return an
+            # empty frame of the expected shape. (Also avoids a pandas trap:
+            # an all-False mask built from an empty list has object dtype, so
+            # df[mask] would select columns rather than filter rows.)
+            return df.set_index(dggs_col)[col_order]
+
         feature_cell_groups = (
             df.groupby(id_field)[dggs_col].apply(lambda x: set(x)).to_dict()
         )


### PR DESCRIPTION
Fixes #112.

Compaction ran per dask partition, so sibling cells of one feature that landed in different partitions could never merge — leaving stripes of finer-than-necessary cells ("seams") wherever bisection and chunking fragmented a feature across partitions. Exposed by #108 now that large geometries genuinely fragment; cell *coverage* was always correct, output was just under-compacted.

**Fix:** shuffle by the parent-cell column before the compaction `map_partitions`. Because the `parent_res` floor means siblings can only merge within one parent cell, co-locating rows by that column makes per-partition compaction globally correct, however features are fragmented. (The shuffle exposed a second latent bug — `compaction_common` crashed on empty partitions via a pandas object-dtype-mask trap — fixed with an early return.)

**Tests** (new `tests/classes/compaction_pipeline.py`, both written first and confirmed failing):
- pipeline test: h3 run with aggressive fragmentation (`-c 50000 -ch 10`) must leave no complete sibling sets uncompacted
- unit test: compaction of an empty partition returns an empty frame of the expected shape

Measured on the test data (`-r 11 -pr 8 -c 50000 -co`, default chunksize): before 805 rows with 13 unmerged sibling septets; after 703 rows, 0 septets — identical to single-partition ground truth. Compaction runthroughs for rHP/geohash/A5 and the compaction-bounds unit tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)