### PR TITLE
Fix linestring cell dedup dropping rows of other features

### DIFF
--- a/tests/classes/linetrace.py
+++ b/tests/classes/linetrace.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+
+import geopandas as gpd
+from shapely.geometry import LineString
+
+from vector2dggs.indexerfactory import indexer_instance
+
+
+class TestLinetraceSetSemantics(TestCase):
+    """
+    Linestring output contract: one row per (feature, cell), for every
+    backend. A cell shared by two features must appear once for each, and a
+    feature re-entering a cell must not produce duplicate rows.
+    """
+
+    RESOLUTIONS = {"h3": 9, "rhp": 8, "s2": 14, "a5": 14, "geohash": 6}
+
+    # Crossing guarantees a shared cell at any resolution
+    LINE_A = LineString([(174.75, -41.30), (174.85, -41.30)])
+    LINE_B = LineString([(174.80, -41.25), (174.80, -41.35)])
+    # Closes back onto its start point, guaranteeing cell re-entry
+    ZIGZAG = LineString(
+        [
+            (174.80, -41.30),
+            (174.85, -41.31),
+            (174.80, -41.32),
+            (174.85, -41.33),
+            (174.80, -41.30),
+        ]
+    )
+
+    def _backends(self):
+        for dggs, res in self.RESOLUTIONS.items():
+            try:
+                yield indexer_instance(dggs), res
+            except ImportError:
+                continue
+
+    @staticmethod
+    def _polyfill(indexer, geoms, res):
+        df = gpd.GeoDataFrame(
+            {"fid": list(range(len(geoms))), "geometry": geoms}, crs=4326
+        )
+        return indexer.polyfill(df, res)
+
+    def test_batch_matches_solo(self):
+        for indexer, res in self._backends():
+            with self.subTest(dggs=indexer.dggs):
+                batch = self._polyfill(indexer, [self.LINE_A, self.LINE_B], res)
+                for fid, line in enumerate([self.LINE_A, self.LINE_B]):
+                    solo = self._polyfill(indexer, [line], res)
+                    batch_cells = set(batch[batch["fid"] == fid].index)
+                    self.assertEqual(batch_cells, set(solo.index))
+
+    def test_no_duplicate_feature_cell_pairs(self):
+        for indexer, res in self._backends():
+            with self.subTest(dggs=indexer.dggs):
+                result = self._polyfill(indexer, [self.ZIGZAG, self.LINE_A], res)
+                pairs = list(zip(result.index, result["fid"], strict=True))
+                self.assertEqual(len(pairs), len(set(pairs)))

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -17,6 +17,7 @@ from .classes.geohash import TestGeohash as TestGeohash
 from .classes.geometry_types import TestGeometryTypes as TestGeometryTypes
 from .classes.h3 import TestH3 as TestH3
 from .classes.katana import TestKatana as TestKatana
+from .classes.linetrace import TestLinetraceSetSemantics as TestLinetraceSetSemantics
 from .classes.output_validation import TestOutputValidation as TestOutputValidation
 from .classes.postgis import TestPostGIS as TestPostGIS
 from .classes.rHP import TestRHP as TestRHP

--- a/vector2dggs/indexers/a5vectorindexer.py
+++ b/vector2dggs/indexers/a5vectorindexer.py
@@ -26,9 +26,10 @@ class A5VectorIndexer(VectorIndexer):
 
     @staticmethod
     def _linetrace(geom, resolution: int) -> list:
+        # set: no documented uniqueness guarantee from line_string_to_cells
         return [
             a5.u64_to_hex(c)
-            for c in a5.line_string_to_cells(list(geom.coords), resolution)
+            for c in set(a5.line_string_to_cells(list(geom.coords), resolution))
         ]
 
     def _polyfill_polygons(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
@@ -39,8 +40,7 @@ class A5VectorIndexer(VectorIndexer):
     def _polyfill_linestrings(
         self, df: gpd.GeoDataFrame, resolution: int
     ) -> pd.DataFrame:
-        result = self._geo_to_cells(df, resolution, self._linetrace, df.geometry.name)
-        return result[~result.index.duplicated(keep="first")]
+        return self._geo_to_cells(df, resolution, self._linetrace, df.geometry.name)
 
     def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
         return self._geo_to_cells(

--- a/vector2dggs/indexers/geohashvectorindexer.py
+++ b/vector2dggs/indexers/geohashvectorindexer.py
@@ -53,7 +53,7 @@ class GeohashVectorIndexer(VectorIndexer):
             .dropna(subset=[gh_col])
             .set_index(gh_col)
         )
-        return pd.DataFrame(result[~result.index.duplicated(keep="first")])
+        return pd.DataFrame(result)
 
     def _polyfill_points(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:
         geom_col = df.geometry.name

--- a/vector2dggs/indexers/h3vectorindexer.py
+++ b/vector2dggs/indexers/h3vectorindexer.py
@@ -35,8 +35,7 @@ class H3VectorIndexer(VectorIndexer):
     def _polyfill_linestrings(
         self, df: gpd.GeoDataFrame, resolution: int
     ) -> pd.DataFrame:
-        result = self._geo_to_cells(df, resolution, self._linetrace, df.geometry.name)
-        return result[~result.index.duplicated(keep="first")]
+        return self._geo_to_cells(df, resolution, self._linetrace, df.geometry.name)
 
     def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
         return self._geo_to_cells(

--- a/vector2dggs/indexers/rhpvectorindexer.py
+++ b/vector2dggs/indexers/rhpvectorindexer.py
@@ -36,13 +36,12 @@ class RHPVectorIndexer(VectorIndexer):
         self, df: gpd.GeoDataFrame, resolution: int
     ) -> pd.DataFrame:
         geom_col = df.geometry.name
-        result = (
-            df.rhp.linetrace(resolution)
-            .explode(COLUMNS["linetrace"])
-            .set_index(COLUMNS["linetrace"])
-            .drop(columns=[geom_col])
-        )
-        return pd.DataFrame(result[~result.index.duplicated(keep="first")])
+        col = COLUMNS["linetrace"]
+        result = df.rhp.linetrace(resolution)
+        # linetrace returns a traversal sequence, which may revisit cells
+        result[col] = result[col].map(lambda cells: list(dict.fromkeys(cells)))
+        result = result.explode(col).set_index(col).drop(columns=[geom_col])
+        return pd.DataFrame(result)
 
     def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
         geom_col = df.geometry.name


### PR DESCRIPTION
Fixes #116.

h3, rhp, a5 and geohash deduplicated exploded linestring cells on cell ID across the whole batch, so a cell shared by two features silently kept only the first feature's row. S2 applied no dedup at all — backends disagreed on the same input.

**Contract:** one row per (feature, cell), for all geometry types and all backends.

**Fix:** dedup each feature's cell list where it is produced (`rhppandas.linetrace` returns traversal sequences that revisit cells; a5's `line_string_to_cells` has no documented uniqueness guarantee), and remove the cross-batch index filter from all four indexers.

**Tests** (new `tests/classes/linetrace.py`, parametrised over installed backends, written first): batch polyfill of two crossing lines must match each line polyfilled alone (failed on h3/rhp/a5/geohash before the fix), and a self-re-entering zigzag must not produce duplicate (feature, cell) rows.

Verified on a sample dataset: a road sharing 15 of 29 cells with a parallel road previously indexed 14 cells; now all four features index completely (29/33/29/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)