### PR TITLE
Fix FD budget extremes; sort by partition column before hive writes

### DIFF
--- a/tests/classes/write_limits.py
+++ b/tests/classes/write_limits.py
@@ -9,21 +9,6 @@ from vector2dggs import common
 from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer
 
 
-class TestMaxOpenFilesPerTask(TestCase):
-    def test_unlimited_rlimit_uses_pyarrow_default(self):
-        # RLIM_INFINITY is -1; must not floor-divide into the minimum
-        self.assertEqual(common._max_open_files_per_task(-1, 8), 1024)
-
-    def test_large_rlimit_is_capped_at_pyarrow_default(self):
-        self.assertEqual(common._max_open_files_per_task(1048576, 8), 1024)
-
-    def test_small_rlimit_many_cores_floors_at_8(self):
-        self.assertEqual(common._max_open_files_per_task(1024, 128), 8)
-
-    def test_mid_range(self):
-        self.assertEqual(common._max_open_files_per_task(4096, 4), 512)
-
-
 @skipIf(common.resource is None, "resource module is POSIX-only")
 class TestRaiseRlimitNofile(TestCase):
     def test_soft_limit_raised_to_hard(self):
@@ -39,8 +24,8 @@ class TestRaiseRlimitNofile(TestCase):
 
 class TestSortedHiveWrite(TestCase):
     """
-    With rows interleaved across many parent cells and a small open-file
-    budget, the write must still produce one file per parent-cell directory
+    With rows interleaved across more parent cells than the open-file pool
+    holds, the write must still produce one file per parent-cell directory
     (rows sorted by partition column, so no writer churn).
     """
 
@@ -62,7 +47,7 @@ class TestSortedHiveWrite(TestCase):
         )
 
         with tempfile.TemporaryDirectory() as out, mock.patch.object(
-            common, "_max_open_files_per_task", return_value=8
+            common.const, "MAX_OPEN_FILES_PER_TASK", 8
         ):
             common.write_partition_as_geoparquet(
                 df,

--- a/tests/classes/write_limits.py
+++ b/tests/classes/write_limits.py
@@ -64,3 +64,32 @@ class TestSortedHiveWrite(TestCase):
             ]
             self.assertEqual(len(counts), 30)
             self.assertEqual(max(counts), 1, f"fragmented dirs: {sorted(counts)}")
+
+    def test_write_spanning_more_than_1024_partitions(self):
+        # pyarrow's max_partitions defaults to 1024; a task's rows can span
+        # far more parent cells than that at fine parent_res
+        parents = list(
+            {
+                h3lib.latlng_to_cell(-47.0 + 0.1 * i, 166.0 + 0.1 * j, 8)
+                for i in range(34)
+                for j in range(34)
+            }
+        )
+        self.assertGreater(len(parents), 1024)
+        df = pd.DataFrame(
+            {"h3_08": parents, "fid": range(len(parents))},
+            index=pd.Index(
+                [h3lib.cell_to_center_child(p, 9) for p in parents], name="h3_09"
+            ),
+        )
+        with tempfile.TemporaryDirectory() as out:
+            common.write_partition_as_geoparquet(
+                df,
+                H3VectorIndexer.cell_to_polygon,
+                Path(out),
+                "h3_08",
+                "h3_09",
+                "snappy",
+            )
+            dirs = [d for d in Path(out).iterdir() if d.is_dir()]
+            self.assertEqual(len(dirs), len(parents))

--- a/tests/classes/write_limits.py
+++ b/tests/classes/write_limits.py
@@ -1,0 +1,81 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase, mock, skipIf
+
+import h3 as h3lib
+import pandas as pd
+
+from vector2dggs import common
+from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer
+
+
+class TestMaxOpenFilesPerTask(TestCase):
+    def test_unlimited_rlimit_uses_pyarrow_default(self):
+        # RLIM_INFINITY is -1; must not floor-divide into the minimum
+        self.assertEqual(common._max_open_files_per_task(-1, 8), 1024)
+
+    def test_large_rlimit_is_capped_at_pyarrow_default(self):
+        self.assertEqual(common._max_open_files_per_task(1048576, 8), 1024)
+
+    def test_small_rlimit_many_cores_floors_at_8(self):
+        self.assertEqual(common._max_open_files_per_task(1024, 128), 8)
+
+    def test_mid_range(self):
+        self.assertEqual(common._max_open_files_per_task(4096, 4), 512)
+
+
+@skipIf(common.resource is None, "resource module is POSIX-only")
+class TestRaiseRlimitNofile(TestCase):
+    def test_soft_limit_raised_to_hard(self):
+        res = common.resource
+        original = res.getrlimit(res.RLIMIT_NOFILE)
+        try:
+            common.raise_rlimit_nofile()
+            soft, hard = res.getrlimit(res.RLIMIT_NOFILE)
+            self.assertEqual(soft, hard)
+        finally:
+            res.setrlimit(res.RLIMIT_NOFILE, original)
+
+
+class TestSortedHiveWrite(TestCase):
+    """
+    With rows interleaved across many parent cells and a small open-file
+    budget, the write must still produce one file per parent-cell directory
+    (rows sorted by partition column, so no writer churn).
+    """
+
+    def test_one_file_per_partition_dir_under_small_budget(self):
+        parents = [
+            h3lib.latlng_to_cell(-41.0 - 0.1 * i, 174.0 + 0.1 * i, 8) for i in range(30)
+        ]
+        # Interleaved round-robin across parents, large enough to span many
+        # write batches: worst case for an LRU writer pool.
+        rows = []
+        for _ in range(700):
+            for k in range(7):
+                for p in parents:
+                    child = h3lib.cell_to_center_child(p, 11)
+                    rows.append((h3lib.cell_to_children(child, 12)[k], p))
+        df = pd.DataFrame(
+            {"h3_08": [p for _, p in rows], "fid": range(len(rows))},
+            index=pd.Index([c for c, _ in rows], name="h3_12"),
+        )
+
+        with tempfile.TemporaryDirectory() as out, mock.patch.object(
+            common, "_max_open_files_per_task", return_value=8
+        ):
+            common.write_partition_as_geoparquet(
+                df,
+                H3VectorIndexer.cell_to_polygon,
+                Path(out),
+                "h3_08",
+                "h3_12",
+                "snappy",
+            )
+            counts = [
+                len(list(d.glob("*.parquet")))
+                for d in Path(out).iterdir()
+                if d.is_dir()
+            ]
+            self.assertEqual(len(counts), 30)
+            self.assertEqual(max(counts), 1, f"fragmented dirs: {sorted(counts)}")

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -22,3 +22,6 @@ from .classes.output_validation import TestOutputValidation as TestOutputValidat
 from .classes.postgis import TestPostGIS as TestPostGIS
 from .classes.rHP import TestRHP as TestRHP
 from .classes.s2 import TestS2 as TestS2
+from .classes.write_limits import TestMaxOpenFilesPerTask as TestMaxOpenFilesPerTask
+from .classes.write_limits import TestRaiseRlimitNofile as TestRaiseRlimitNofile
+from .classes.write_limits import TestSortedHiveWrite as TestSortedHiveWrite

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -22,6 +22,5 @@ from .classes.output_validation import TestOutputValidation as TestOutputValidat
 from .classes.postgis import TestPostGIS as TestPostGIS
 from .classes.rHP import TestRHP as TestRHP
 from .classes.s2 import TestS2 as TestS2
-from .classes.write_limits import TestMaxOpenFilesPerTask as TestMaxOpenFilesPerTask
 from .classes.write_limits import TestRaiseRlimitNofile as TestRaiseRlimitNofile
 from .classes.write_limits import TestSortedHiveWrite as TestSortedHiveWrite

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -169,6 +169,7 @@ def make_dggs_command(
         overwrite: bool,
     ):
         tempfile.tempdir = str(tempdir) if tempdir is not None else tempfile.tempdir
+        common.raise_rlimit_nofile()
 
         common.check_resolutions(resolution, parent_res)
         common.check_compaction_requirements(compact, id_field)

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -305,6 +305,9 @@ def write_partition_as_geoparquet(
         basename_template=f"part.{{i}}-{uuid4().hex}.parquet",
         use_threads=True,
         max_open_files=const.MAX_OPEN_FILES_PER_TASK,
+        # pyarrow's default max_partitions (1024) is a safety valve; this
+        # batch's true partition count is known, so pass it exactly
+        max_partitions=max(1, int(pdf[partition_col].nunique())),
     )
 
     return int(len(pdf.index) > 0)

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -189,31 +189,6 @@ def raise_rlimit_nofile() -> None:
         LOGGER.debug("Could not raise RLIMIT_NOFILE: %s", e)
 
 
-def _max_open_files_per_task(
-    soft_limit: int | None = None, concurrency: int | None = None
-) -> int:
-    """
-    Per-write-task max_open_files for pq.write_to_dataset: a share of the
-    soft RLIMIT_NOFILE across concurrent tasks, clamped to [8, pyarrow's
-    default]. Rows are written sorted by partition column, so even the
-    floor cannot fragment output.
-    """
-    if soft_limit is None:
-        soft_limit = (
-            resource.getrlimit(resource.RLIMIT_NOFILE)[0]
-            if resource is not None
-            else const.FALLBACK_RLIMIT_NOFILE
-        )
-    if soft_limit <= 0:  # RLIM_INFINITY is -1
-        return const.PYARROW_DEFAULT_MAX_OPEN_FILES
-    if concurrency is None:
-        concurrency = os.cpu_count() or 1
-    return min(
-        const.PYARROW_DEFAULT_MAX_OPEN_FILES,
-        max(8, soft_limit // (2 * concurrency)),
-    )
-
-
 def write_partition_as_geoparquet(
     partition_df: pd.DataFrame,
     geo_serialisation_method,
@@ -329,7 +304,7 @@ def write_partition_as_geoparquet(
         compression=compression,
         basename_template=f"part.{{i}}-{uuid4().hex}.parquet",
         use_threads=True,
-        max_open_files=_max_open_files_per_task(),
+        max_open_files=const.MAX_OPEN_FILES_PER_TASK,
     )
 
     return int(len(pdf.index) > 0)

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -176,27 +176,42 @@ def get_parent_res(dggs: str, parent_res: None | str | int, resolution: int) -> 
     )
 
 
-def _max_open_files_per_task() -> int:
-    """
-    Bound how many files pq.write_to_dataset may leave open within a single
-    write task.
+def raise_rlimit_nofile() -> None:
+    """Raise the soft RLIMIT_NOFILE to the hard limit (POSIX; no-op elsewhere)."""
+    if resource is None:
+        return
+    try:
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft != hard:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))
+            LOGGER.debug("Raised RLIMIT_NOFILE soft limit from %s to %s", soft, hard)
+    except (ValueError, OSError) as e:
+        LOGGER.debug("Could not raise RLIMIT_NOFILE: %s", e)
 
-    pyarrow's default (max_open_files=900) is on its own often almost the entire
-    process's file descriptor limit. Since dask runs multiple of these write
-    tasks concurrently (one per spatial partition, each independently
-    allowed to open up to that many files), the process can exceed its file
-    descriptor limit with "Too many open files" - especially with finer
-    parent_res values, which produce many more distinct output partitions
-    per task. Divide the soft limit across the concurrent tasks, leaving
-    headroom for other open files (input reads, etc.).
+
+def _max_open_files_per_task(
+    soft_limit: int | None = None, concurrency: int | None = None
+) -> int:
     """
-    soft_limit = (
-        resource.getrlimit(resource.RLIMIT_NOFILE)[0]
-        if resource is not None
-        else const.FALLBACK_RLIMIT_NOFILE
+    Per-write-task max_open_files for pq.write_to_dataset: a share of the
+    soft RLIMIT_NOFILE across concurrent tasks, clamped to [8, pyarrow's
+    default]. Rows are written sorted by partition column, so even the
+    floor cannot fragment output.
+    """
+    if soft_limit is None:
+        soft_limit = (
+            resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+            if resource is not None
+            else const.FALLBACK_RLIMIT_NOFILE
+        )
+    if soft_limit <= 0:  # RLIM_INFINITY is -1
+        return const.PYARROW_DEFAULT_MAX_OPEN_FILES
+    if concurrency is None:
+        concurrency = os.cpu_count() or 1
+    return min(
+        const.PYARROW_DEFAULT_MAX_OPEN_FILES,
+        max(8, soft_limit // (2 * concurrency)),
     )
-    concurrency = max(1, os.cpu_count() or 1)
-    return max(8, soft_limit // (2 * concurrency))
 
 
 def write_partition_as_geoparquet(
@@ -268,6 +283,9 @@ def write_partition_as_geoparquet(
     pdf = partition_df.copy()
     pdf[partition_col] = pdf[partition_col].astype("string")
     pdf["geometry"] = shapely.to_wkb(geoms, hex=False)
+    # Contiguous partition values: one output file per parent cell, no
+    # writer churn under a small max_open_files
+    pdf = pdf.sort_values(partition_col, kind="stable")
 
     table = pa.Table.from_pandas(pdf, preserve_index=True)
 

--- a/vector2dggs/constants.py
+++ b/vector2dggs/constants.py
@@ -13,6 +13,9 @@ MIN_A5, MAX_A5 = 0, 30
 # cannot be queried (e.g. Windows, where the `resource` module is unavailable).
 FALLBACK_RLIMIT_NOFILE = 1024
 
+# pyarrow's own default for write_dataset(max_open_files=...); never exceed it
+PYARROW_DEFAULT_MAX_OPEN_FILES = 1024
+
 
 @unique
 class SpatialSortingMethod(StrEnum):

--- a/vector2dggs/constants.py
+++ b/vector2dggs/constants.py
@@ -9,12 +9,10 @@ MIN_S2, MAX_S2 = 0, 30
 MIN_GEOHASH, MAX_GEOHASH = 1, 12
 MIN_A5, MAX_A5 = 0, 30
 
-# Assumed file descriptor soft limit (RLIMIT_NOFILE) on platforms where it
-# cannot be queried (e.g. Windows, where the `resource` module is unavailable).
-FALLBACK_RLIMIT_NOFILE = 1024
-
-# pyarrow's own default for write_dataset(max_open_files=...); never exceed it
-PYARROW_DEFAULT_MAX_OPEN_FILES = 1024
+# max_open_files per pq.write_to_dataset call. Rows are written sorted by
+# partition column, so a small pool cannot fragment output; a small fixed
+# value keeps total FD use safe under any concurrency and rlimit.
+MAX_OPEN_FILES_PER_TASK = 64
 
 
 @unique


### PR DESCRIPTION
Fixes #118.

Replaces the adaptive `max_open_files` budget from #77 with something simpler and safer:

1. **Sort each batch by the partition column** before `pq.write_to_dataset`. The writer then finishes each parent-cell directory before moving on, so even a tiny open-file pool yields exactly one file per directory — no writer churn, no fragment merging. Benchmarked earlier as the fastest configuration (~5× over unsorted at a small pool) with ~19% smaller output.
2. **Fixed small cap** (`MAX_OPEN_FILES_PER_TASK = 64`): with sorted input a small pool is free, so a flat constant replaces the rlimit-divided-by-CPU heuristic entirely — safe under any concurrency and any hard limit, with no `RLIM_INFINITY` arithmetic to get wrong.
3. **Raise the soft `RLIMIT_NOFILE` to the hard limit** once at CLI startup (no privileges needed; no-op on non-POSIX), protecting every file consumer in the process.
4. **Pass the batch's true partition count as `max_partitions`**: pyarrow's default (1024) rejects write tasks spanning more parent cells than that, which fine `parent_res` values routinely produce (`ArrowInvalid: Fragment would be written into 2458 partitions`) — reproduced on real topo50 data with `-r 9 -pr 8`, and pre-existing on main.

**Tests** (new `tests/classes/write_limits.py`, written first): the soft-limit raise, a ~147k-row interleaved write under a forced pool of 8 that must produce one file per partition directory (previously 3–5 fragments each), and a write spanning >1024 partitions (previously `ArrowInvalid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)