### PR TITLE
Raise a clear error for CRS-less input

### DIFF
--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
 import click
+import geopandas as gpd
+from shapely.geometry import Polygon
 
 from vector2dggs import common
 from vector2dggs.h3 import h3
@@ -15,6 +17,13 @@ class TestErrors(TestCase):
     Error-path unit tests that raise before touching the filesystem,
     so no output cleanup is needed.
     """
+
+    def test_crsless_input_raises_clear_error(self):
+        naive = gpd.GeoDataFrame(
+            {"geometry": [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])]}
+        )
+        with self.assertRaisesRegex(ValueError, "CRS"):
+            common.bisection_preparation(naive, "h3", 5, None, None)
 
     def test_invalid_compression_raises(self):
         with self.assertRaises(click.BadParameter):

--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -1,3 +1,5 @@
+import tempfile
+import warnings
 from unittest import TestCase
 
 import click
@@ -24,6 +26,29 @@ class TestErrors(TestCase):
         )
         with self.assertRaisesRegex(ValueError, "CRS"):
             common.bisection_preparation(naive, "h3", 5, None, None)
+
+    def test_crsless_file_rejected_before_any_processing(self):
+        naive = gpd.GeoDataFrame(
+            {"geometry": [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])]}
+        )
+        with tempfile.TemporaryDirectory() as d:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                naive.to_file(f"{d}/naive.gpkg", layer="naive")
+            with self.assertRaisesRegex(ValueError, "CRS"):
+                common.index(
+                    "h3",
+                    f"{d}/naive.gpkg",
+                    f"{d}/out.pq",
+                    9,
+                    5,
+                    False,
+                    50,
+                    "none",
+                    None,
+                    1,
+                    layer="naive",
+                )
 
     def test_invalid_compression_raises(self):
         with self.assertRaises(click.BadParameter):

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -553,8 +553,6 @@ def bisection_preparation(
             "Input has no CRS, which is required for indexing. "
             "Provide a dataset with a defined CRS."
         )
-    elif cut_threshold != 0:
-        LOGGER.debug("Cutting with CRS: %s", df.crs)
 
     if not cut_crs.is_projected and cut_threshold != 0:
         LOGGER.warning(
@@ -848,6 +846,11 @@ def index(
             layer if layer else "<default>",
         )
         return output_directory
+    if df.crs is None:
+        raise ValueError(
+            "Input has no CRS, which is required for indexing. "
+            "Provide a dataset with a defined CRS."
+        )
 
     df, cut_crs, cut_threshold = bisection_preparation(
         df, dggs, parent_res, cut_crs, cut_threshold

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -549,7 +549,10 @@ def bisection_preparation(
         cut_crs = df.crs
 
     if cut_crs is None:
-        LOGGER.warning("Input has no defined CRS, and cut_crs is not specified")
+        raise ValueError(
+            "Input has no CRS, which is required for indexing. "
+            "Provide a dataset with a defined CRS."
+        )
     elif cut_threshold != 0:
         LOGGER.debug("Cutting with CRS: %s", df.crs)
 


### PR DESCRIPTION
Fixes #120.

Input with no CRS hit a warning branch and then crashed one line later on `cut_crs.is_projected` (`AttributeError: 'NoneType' …`). Since indexing cannot proceed without a CRS anyway, the warning is now a `ValueError` with an actionable message.

Test (written first, failed with the original `AttributeError`): a CRS-less GeoDataFrame must raise `ValueError` mentioning "CRS".

🤖 Generated with [Claude Code](https://claude.com/claude-code)