### PR TITLE
Drop null cells after exploding S2 and rHP linestring traces

### DIFF
--- a/tests/classes/linetrace.py
+++ b/tests/classes/linetrace.py
@@ -1,6 +1,7 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import geopandas as gpd
+import pandas as pd
 from shapely.geometry import LineString
 
 from vector2dggs.indexerfactory import indexer_instance
@@ -58,3 +59,58 @@ class TestLinetraceSetSemantics(TestCase):
                 result = self._polyfill(indexer, [self.ZIGZAG, self.LINE_A], res)
                 pairs = list(zip(result.index, result["fid"], strict=True))
                 self.assertEqual(len(pairs), len(set(pairs)))
+
+
+class TestEmptyTraces(TestCase):
+    """
+    A linestring whose trace yields no cells must contribute no rows - not a
+    NaN-indexed row (which crashes S2's secondary_index and silently
+    propagates into rHP output).
+    """
+
+    LINE = LineString([(174.75, -41.30), (174.85, -41.30)])
+
+    def _assert_no_nan_rows(self, indexer, result, n_expected_features):
+        self.assertTrue(result.index.notna().all(), "NaN cell rows leaked")
+        self.assertEqual(result["fid"].nunique(), n_expected_features)
+
+    def test_rhp_empty_trace_is_dropped(self):
+        try:
+            indexer = indexer_instance("rhp")
+        except ImportError:
+            self.skipTest("rhp backend not installed")
+        df = gpd.GeoDataFrame(
+            {"fid": [0, 1], "geometry": [self.LINE, self.LINE]}, crs=4326
+        )
+        accessor_cls = type(df.rhp)
+        real = accessor_cls.linetrace
+
+        def fake(self_acc, resolution):
+            out = real(self_acc, resolution)
+            col = out.columns[-1]
+            values = out[col].tolist()
+            values[0] = []
+            out[col] = pd.Series(values, index=out.index)
+            return out
+
+        with mock.patch.object(accessor_cls, "linetrace", fake):
+            result = indexer._polyfill_linestrings(df, 6)
+        self._assert_no_nan_rows(indexer, result, 1)
+
+    def test_s2_empty_trace_is_dropped(self):
+        try:
+            indexer = indexer_instance("s2")
+        except ImportError:
+            self.skipTest("s2 backend not installed")
+        df = gpd.GeoDataFrame(
+            {"fid": [0, 1], "geometry": [self.LINE, self.LINE]}, crs=4326
+        )
+        real = type(indexer).cell_ids_from_linestring
+        calls = iter([True, False])
+
+        def fake(self_idx, geom, level):
+            return [] if next(calls) else real(self_idx, geom, level)
+
+        with mock.patch.object(type(indexer), "cell_ids_from_linestring", fake):
+            result = indexer._polyfill_linestrings(df, 14)
+        self._assert_no_nan_rows(indexer, result, 1)

--- a/tests/classes/linetrace.py
+++ b/tests/classes/linetrace.py
@@ -114,3 +114,23 @@ class TestEmptyTraces(TestCase):
         with mock.patch.object(type(indexer), "cell_ids_from_linestring", fake):
             result = indexer._polyfill_linestrings(df, 14)
         self._assert_no_nan_rows(indexer, result, 1)
+
+    def test_s2_subcell_polygon_is_dropped(self):
+        try:
+            indexer = indexer_instance("s2")
+        except ImportError:
+            self.skipTest("s2 backend not installed")
+        from shapely.geometry import Polygon
+
+        tiny = Polygon(  # ~1 m^2: no level-10 cell centre can fall inside
+            [
+                (174.75, -41.30),
+                (174.75001, -41.30),
+                (174.75001, -41.30001),
+                (174.75, -41.30001),
+            ]
+        )
+        big = Polygon([(174.7, -41.3), (174.9, -41.3), (174.9, -41.2), (174.7, -41.2)])
+        df = gpd.GeoDataFrame({"fid": [0, 1], "geometry": [tiny, big]}, crs=4326)
+        result = indexer._polyfill_polygons(df, 10)
+        self._assert_no_nan_rows(indexer, result, 1)

--- a/vector2dggs/indexers/rhpvectorindexer.py
+++ b/vector2dggs/indexers/rhpvectorindexer.py
@@ -40,7 +40,12 @@ class RHPVectorIndexer(VectorIndexer):
         result = df.rhp.linetrace(resolution)
         # linetrace returns a traversal sequence, which may revisit cells
         result[col] = result[col].map(lambda cells: list(dict.fromkeys(cells)))
-        result = result.explode(col).set_index(col).drop(columns=[geom_col])
+        result = (
+            result.explode(col)
+            .dropna(subset=[col])
+            .set_index(col)
+            .drop(columns=[geom_col])
+        )
         return pd.DataFrame(result)
 
     def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:

--- a/vector2dggs/indexers/rhpvectorindexer.py
+++ b/vector2dggs/indexers/rhpvectorindexer.py
@@ -41,10 +41,10 @@ class RHPVectorIndexer(VectorIndexer):
         # linetrace returns a traversal sequence, which may revisit cells
         result[col] = result[col].map(lambda cells: list(dict.fromkeys(cells)))
         result = (
-            result.explode(col)
+            result.drop(columns=[geom_col])
+            .explode(col)
             .dropna(subset=[col])
             .set_index(col)
-            .drop(columns=[geom_col])
         )
         return pd.DataFrame(result)
 

--- a/vector2dggs/indexers/s2vectorindexer.py
+++ b/vector2dggs/indexers/s2vectorindexer.py
@@ -36,7 +36,12 @@ class S2VectorIndexer(VectorIndexer):
         df["s2index"] = df.geometry.apply(
             lambda geom: self.cell_ids_from_linestring(geom, level)
         )
-        result = df.drop(columns=[geom_col]).explode("s2index").set_index("s2index")
+        result = (
+            df.drop(columns=[geom_col])
+            .explode("s2index")
+            .dropna(subset=["s2index"])
+            .set_index("s2index")
+        )
         return pd.DataFrame(result)
 
     def _polyfill_points(self, df: gpd.GeoDataFrame, level: int) -> pd.DataFrame:

--- a/vector2dggs/indexers/s2vectorindexer.py
+++ b/vector2dggs/indexers/s2vectorindexer.py
@@ -24,9 +24,10 @@ class S2VectorIndexer(VectorIndexer):
         geom_col = df.geometry.name
         result = (
             self.polyfill_polygons(df.copy(), level)
-            .explode("s2index")
-            .set_index("s2index")
             .drop(columns=[geom_col])
+            .explode("s2index")
+            .dropna(subset=["s2index"])
+            .set_index("s2index")
         )
         return pd.DataFrame(result)
 


### PR DESCRIPTION
Fixes #126.

The shared `_geo_to_cells` helper drops null cells after exploding (protecting h3/a5), and geohash has its own `dropna` — but the hand-built S2 and rHP paths didn't: a trace or covering that returns no cells exploded into a NaN-indexed row. For S2, `secondary_index` then called `.parent()`/`.ToToken()` on the NaN and killed the partition worker; for rHP the NaN cell propagated silently into the output.

Affected paths, all fixed with a `dropna` after explode and normalised to the same chain order (`drop(geometry) → explode → dropna → set_index`):
- S2 linestrings (empty polyline trace)
- rHP linestrings (rhppandas `linetrace` is documented incomplete near cap cells)
- S2 polygons (a polygon smaller than a cell yields an empty covering after the centre-inside filter — probably the most common trigger)

**Tests** (written first; rHP confirmed failing locally with "NaN cell rows leaked"): stubbed empty traces for S2/rHP linestrings, and a real ~1 m² polygon for the S2 polygon case. The S2 tests execute in CI (s2geometry not installable in this dev environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)