### PR TITLE
Skip tests for missing optional backends instead of failing collection

### DIFF
--- a/tests/classes/a5.py
+++ b/tests/classes/a5.py
@@ -9,13 +9,18 @@ from ..data.datapaths import (
     TEST_POINT_FILE_PATH,
     TEST_POINT_LAYER_NAME,
 )
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestA5(TestRunthrough):
     """
     Sends the test data file through A5 indexing using default parameters.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        skip_unless_backend("a5")
+        super().setUpClass()
 
     def test_a5_run(self):
         a5(

--- a/tests/classes/antimeridian.py
+++ b/tests/classes/antimeridian.py
@@ -13,7 +13,6 @@ from vector2dggs.common import (
 )
 from vector2dggs.h3 import h3
 from vector2dggs.indexerfactory import indexer_instance
-from vector2dggs.indexers.rhpvectorindexer import RHPVectorIndexer
 from vector2dggs.rHP import rhp
 
 from ..data.datapaths import (
@@ -21,7 +20,7 @@ from ..data.datapaths import (
     TEST_ANTIMERIDIAN_LAYER_NAME,
     TEST_OUTPUT_PATH,
 )
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestAntimeridian(TestRunthrough):
@@ -55,7 +54,8 @@ class TestAntimeridian(TestRunthrough):
         return _clean_geometries(df, indexer)
 
     def test_clean_geometries_splits_for_backends_that_require_it(self):
-        cleaned = self._cleaned_via_full_pipeline(RHPVectorIndexer("rhp"))
+        skip_unless_backend("rhp")
+        cleaned = self._cleaned_via_full_pipeline(indexer_instance("rhp"))
 
         self.assertEqual(len(cleaned), 2)
         self.assertTrue((cleaned.geometry.geom_type == "Polygon").all())
@@ -68,6 +68,7 @@ class TestAntimeridian(TestRunthrough):
     def test_h3_run_across_antimeridian(self):
         """H3 doesn't require the pre-split fix - it indexes this correctly
         on its own."""
+        skip_unless_backend("h3")
         h3(
             [
                 TEST_ANTIMERIDIAN_FILE_PATH,
@@ -95,6 +96,7 @@ class TestAntimeridian(TestRunthrough):
     def test_rhp_run_across_antimeridian(self):
         """rHEALPix requires the pre-split fix; without it, the unfixed
         reprojection artifact indexes as ~322 cells instead of ~2."""
+        skip_unless_backend("rhp")
         rhp(
             [
                 TEST_ANTIMERIDIAN_FILE_PATH,

--- a/tests/classes/base.py
+++ b/tests/classes/base.py
@@ -1,6 +1,16 @@
-from unittest import TestCase
+from unittest import SkipTest, TestCase
+
+from vector2dggs.indexerfactory import indexer_instance
 
 from ..data.datapaths import TEST_OUTPUT_PATH
+
+
+def skip_unless_backend(dggs: str) -> None:
+    """Skip the calling test/class when the backend's extra isn't installed."""
+    try:
+        indexer_instance(dggs)
+    except ImportError as e:
+        raise SkipTest(str(e)) from e
 
 
 class TestRunthrough(TestCase):

--- a/tests/classes/compaction.py
+++ b/tests/classes/compaction.py
@@ -1,18 +1,40 @@
 from itertools import product
 from unittest import TestCase
 
-import a5
-import h3
 import pandas as pd
-import s2geometry as S2
-from rhealpixdggs.rhp_wrappers import rhp_get_resolution
 
-from vector2dggs.indexers.a5vectorindexer import A5VectorIndexer
-from vector2dggs.indexers.geohashvectorindexer import GeohashVectorIndexer
-from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer
-from vector2dggs.indexers.rhpvectorindexer import RHPVectorIndexer
-from vector2dggs.indexers.s2vectorindexer import S2VectorIndexer
 from vector2dggs.indexers.vectorindexer import VectorIndexer
+
+from .base import skip_unless_backend
+
+try:
+    import h3
+
+    from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer
+except ImportError:
+    h3 = None
+try:
+    import a5
+
+    from vector2dggs.indexers.a5vectorindexer import A5VectorIndexer
+except ImportError:
+    a5 = None
+try:
+    import s2geometry as S2
+
+    from vector2dggs.indexers.s2vectorindexer import S2VectorIndexer
+except ImportError:
+    S2 = None
+try:
+    from rhealpixdggs.rhp_wrappers import rhp_get_resolution
+
+    from vector2dggs.indexers.rhpvectorindexer import RHPVectorIndexer
+except ImportError:
+    rhp_get_resolution = None
+try:
+    from vector2dggs.indexers.geohashvectorindexer import GeohashVectorIndexer
+except ImportError:
+    GeohashVectorIndexer = None
 
 
 class TestH3CompactionBounds(TestCase):
@@ -23,6 +45,7 @@ class TestH3CompactionBounds(TestCase):
     """
 
     def setUp(self):
+        skip_unless_backend("h3")
         self.parent_res = 5
         # An ancestor one level coarser than parent_res, fully covered by all
         # of its grandchildren at parent_res + 1.
@@ -75,6 +98,7 @@ class TestGeohashCompactionBounds(TestCase):
     """
 
     def setUp(self):
+        skip_unless_backend("geohash")
         self.parent_res = 2
         self.ancestor = "s"
         self.res = self.parent_res + 1
@@ -130,6 +154,7 @@ class TestRHPCompactionBounds(TestCase):
     """
 
     def setUp(self):
+        skip_unless_backend("rhp")
         self.parent_res = 5
         # An ancestor one level coarser than parent_res, fully covered by all
         # of its grandchildren at parent_res + 1.
@@ -192,6 +217,7 @@ class TestS2CompactionBounds(TestCase):
     """
 
     def setUp(self):
+        skip_unless_backend("s2")
         self.parent_res = 10
         # An ancestor one level coarser than parent_res, fully covered by all
         # of its grandchildren at parent_res + 1.
@@ -271,6 +297,7 @@ class TestA5CompactionBounds(TestCase):
     """
 
     def setUp(self):
+        skip_unless_backend("a5")
         self.parent_res = 2
         # An ancestor one level coarser than parent_res, fully covered by all
         # of its grandchildren at parent_res + 1.

--- a/tests/classes/geohash.py
+++ b/tests/classes/geohash.py
@@ -9,13 +9,18 @@ from ..data.datapaths import (
     TEST_POINT_FILE_PATH,
     TEST_POINT_LAYER_NAME,
 )
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestGeohash(TestRunthrough):
     """
     Sends the test data file through Geohash indexing using default parameters.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        skip_unless_backend("geohash")
+        super().setUpClass()
 
     def test_geohash_run(self):
         geohash(

--- a/tests/classes/geometry_types.py
+++ b/tests/classes/geometry_types.py
@@ -7,7 +7,7 @@ from ..data.datapaths import (
     TEST_POINT_FILE_PATH,
     TEST_POINT_LAYER_NAME,
 )
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestGeometryTypes(TestRunthrough):
@@ -16,6 +16,11 @@ class TestGeometryTypes(TestRunthrough):
     Uses H3 as the reference backend. Bisection is disabled (-c 0) since the
     fixtures are small and these tests are purely about geometry-type routing.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        skip_unless_backend("h3")
+        super().setUpClass()
 
     def test_h3_linestring(self):
         h3(

--- a/tests/classes/h3.py
+++ b/tests/classes/h3.py
@@ -9,13 +9,18 @@ from ..data.datapaths import (
     TEST_POINT_FILE_PATH,
     TEST_POINT_LAYER_NAME,
 )
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestH3(TestRunthrough):
     """
     Sends the test data file through H3 indexing using default parameters.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        skip_unless_backend("h3")
+        super().setUpClass()
 
     def test_h3_run(self):
         h3(

--- a/tests/classes/output_validation.py
+++ b/tests/classes/output_validation.py
@@ -5,7 +5,7 @@ import pyarrow.parquet as pq
 from vector2dggs.h3 import h3
 
 from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME, TEST_OUTPUT_PATH
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestOutputValidation(TestRunthrough):
@@ -14,6 +14,11 @@ class TestOutputValidation(TestRunthrough):
     correctness. Uses H3 at resolution 8 (default parent_res=2) as the
     reference backend throughout.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        skip_unless_backend("h3")
+        super().setUpClass()
 
     def _parquet_files(self):
         files = sorted(TEST_OUTPUT_PATH.rglob("*.parquet"))

--- a/tests/classes/rHP.py
+++ b/tests/classes/rHP.py
@@ -9,13 +9,18 @@ from ..data.datapaths import (
     TEST_POINT_FILE_PATH,
     TEST_POINT_LAYER_NAME,
 )
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestRHP(TestRunthrough):
     """
     Sends the test data file through rHP indexing using default parameters.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        skip_unless_backend("rhp")
+        super().setUpClass()
 
     def test_rhp_run(self):
         rhp(

--- a/tests/classes/s2.py
+++ b/tests/classes/s2.py
@@ -9,13 +9,18 @@ from ..data.datapaths import (
     TEST_POINT_FILE_PATH,
     TEST_POINT_LAYER_NAME,
 )
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestS2(TestRunthrough):
     """
     Sends the test data file through S2 indexing using default parameters.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        skip_unless_backend("s2")
+        super().setUpClass()
 
     def test_s2_run(self):
         s2(

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -1,26 +1,56 @@
-from .classes.a5 import TestA5 as TestA5
-from .classes.antimeridian import TestAntimeridian as TestAntimeridian
-from .classes.bisection import TestBisection as TestBisection
-from .classes.compaction import TestA5CompactionBounds as TestA5CompactionBounds
-from .classes.compaction import (
-    TestGeohashCompactionBounds as TestGeohashCompactionBounds,
-)
-from .classes.compaction import TestH3CompactionBounds as TestH3CompactionBounds
-from .classes.compaction import TestRHPCompactionBounds as TestRHPCompactionBounds
-from .classes.compaction import TestS2CompactionBounds as TestS2CompactionBounds
-from .classes.compaction_pipeline import (
-    TestCompactionAcrossPartitions as TestCompactionAcrossPartitions,
-)
-from .classes.errors import TestErrors as TestErrors
-from .classes.errors import TestOverwriteRequired as TestOverwriteRequired
-from .classes.geohash import TestGeohash as TestGeohash
-from .classes.geometry_types import TestGeometryTypes as TestGeometryTypes
-from .classes.h3 import TestH3 as TestH3
-from .classes.katana import TestKatana as TestKatana
-from .classes.linetrace import TestLinetraceSetSemantics as TestLinetraceSetSemantics
-from .classes.output_validation import TestOutputValidation as TestOutputValidation
-from .classes.postgis import TestPostGIS as TestPostGIS
-from .classes.rHP import TestRHP as TestRHP
-from .classes.s2 import TestS2 as TestS2
-from .classes.write_limits import TestRaiseRlimitNofile as TestRaiseRlimitNofile
-from .classes.write_limits import TestSortedHiveWrite as TestSortedHiveWrite
+# Aggregates the test classes under tests/classes/ for pytest discovery.
+# Imports are optional: a module whose backend extra is not installed is
+# omitted rather than failing collection (see also skip_unless_backend).
+# ruff: noqa: E402
+import contextlib
+
+with contextlib.suppress(ImportError):
+    from .classes.a5 import TestA5 as TestA5
+with contextlib.suppress(ImportError):
+    from .classes.antimeridian import TestAntimeridian as TestAntimeridian
+with contextlib.suppress(ImportError):
+    from .classes.bisection import TestBisection as TestBisection
+with contextlib.suppress(ImportError):
+    from .classes.compaction import TestA5CompactionBounds as TestA5CompactionBounds
+with contextlib.suppress(ImportError):
+    from .classes.compaction import (
+        TestGeohashCompactionBounds as TestGeohashCompactionBounds,
+    )
+with contextlib.suppress(ImportError):
+    from .classes.compaction import TestH3CompactionBounds as TestH3CompactionBounds
+with contextlib.suppress(ImportError):
+    from .classes.compaction import TestRHPCompactionBounds as TestRHPCompactionBounds
+with contextlib.suppress(ImportError):
+    from .classes.compaction import TestS2CompactionBounds as TestS2CompactionBounds
+with contextlib.suppress(ImportError):
+    from .classes.compaction_pipeline import (
+        TestCompactionAcrossPartitions as TestCompactionAcrossPartitions,
+    )
+with contextlib.suppress(ImportError):
+    from .classes.errors import TestErrors as TestErrors
+with contextlib.suppress(ImportError):
+    from .classes.errors import TestOverwriteRequired as TestOverwriteRequired
+with contextlib.suppress(ImportError):
+    from .classes.geohash import TestGeohash as TestGeohash
+with contextlib.suppress(ImportError):
+    from .classes.geometry_types import TestGeometryTypes as TestGeometryTypes
+with contextlib.suppress(ImportError):
+    from .classes.h3 import TestH3 as TestH3
+with contextlib.suppress(ImportError):
+    from .classes.katana import TestKatana as TestKatana
+with contextlib.suppress(ImportError):
+    from .classes.linetrace import (
+        TestLinetraceSetSemantics as TestLinetraceSetSemantics,
+    )
+with contextlib.suppress(ImportError):
+    from .classes.output_validation import TestOutputValidation as TestOutputValidation
+with contextlib.suppress(ImportError):
+    from .classes.postgis import TestPostGIS as TestPostGIS
+with contextlib.suppress(ImportError):
+    from .classes.rHP import TestRHP as TestRHP
+with contextlib.suppress(ImportError):
+    from .classes.s2 import TestS2 as TestS2
+with contextlib.suppress(ImportError):
+    from .classes.write_limits import TestRaiseRlimitNofile as TestRaiseRlimitNofile
+with contextlib.suppress(ImportError):
+    from .classes.write_limits import TestSortedHiveWrite as TestSortedHiveWrite


### PR DESCRIPTION
Fixes #128.

One missing optional extra previously killed collection of the whole suite (`ModuleNotFoundError` importing `tests/test_runthrough.py`) — zero tests could run, including backend-free ones. Partial installs are a documented, supported configuration.

**Fix:** backend imports in the aggregator and `compaction.py` are now optional (`contextlib.suppress(ImportError)` / guarded imports), and every backend-dependent test class skips via a shared `skip_unless_backend` helper when its extra isn't installed — same pattern as the existing Docker-gated PostGIS tests. Skips are visible in the pytest summary rather than silent.

Verified in an env without `s2geometry`: before, 0 tests collectable; after, **128 passed / 24 skipped**. CI (which installs `-E all`) runs everything as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)