### PR TITLE
Never fork the indexing pool; report features that produce no cells

### DIFF
--- a/tests/classes/bisection.py
+++ b/tests/classes/bisection.py
@@ -94,3 +94,45 @@ class TestBisectionPreparation(TestCase):
         metres_per_degree = 111_195  # pi/180 * mean earth radius
         expected = m2 / metres_per_degree**2
         self.assertAlmostEqual(threshold, expected, delta=expected * 0.001)
+
+
+class TestDroppedFeatureReport(TestCase):
+    def test_features_with_no_cells_are_reported(self):
+        import tempfile
+        import warnings as _warnings
+
+        big = Polygon([(174.7, -41.3), (174.9, -41.3), (174.9, -41.2), (174.7, -41.2)])
+        tiny = Polygon(  # ~1 m^2: produces no cells at a coarse resolution
+            [
+                (174.75, -41.30),
+                (174.75001, -41.30),
+                (174.75001, -41.30001),
+                (174.75, -41.30001),
+            ]
+        )
+        df = gpd.GeoDataFrame(
+            {"name": ["big", "tiny"], "geometry": [big, tiny]}, crs=4326
+        )
+        with tempfile.TemporaryDirectory() as d:
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("ignore")
+                df.to_file(f"{d}/in.gpkg", layer="x")
+            with self.assertLogs(common.LOGGER, level="WARNING") as logs:
+                common.index(
+                    "h3",
+                    f"{d}/in.gpkg",
+                    f"{d}/out.pq",
+                    7,
+                    None,
+                    False,
+                    50,
+                    "none",
+                    0.0,
+                    1,
+                    layer="x",
+                    compact=False,
+                )
+        self.assertTrue(
+            any("1 of 2 features produced no cells" in m for m in logs.output),
+            logs.output,
+        )

--- a/tests/classes/write_limits.py
+++ b/tests/classes/write_limits.py
@@ -93,3 +93,8 @@ class TestSortedHiveWrite(TestCase):
             )
             dirs = [d for d in Path(out).iterdir() if d.is_dir()]
             self.assertEqual(len(dirs), len(parents))
+
+
+class TestProcessPoolContext(TestCase):
+    def test_indexing_pool_does_not_fork(self):
+        self.assertNotEqual(common._mp_context().get_start_method(), "fork")

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -1,6 +1,7 @@
 import errno
 import json
 import logging
+import multiprocessing
 import os
 import shutil
 import tempfile
@@ -462,26 +463,27 @@ def _polyfill(
     resolution: int,
     parent_res: int,
     output_directory: str,
-    compression: str = "snappy",
-) -> None:
+    compression: str,
+    id_col: str,
+) -> np.ndarray:
     """
     Reads a geoparquet, performs polyfilling (for Polygon),
     linetracing (for LineString), or indexing (for Point),
-    and writes out to parquet.
+    and writes out to parquet. Returns the ids of features that
+    produced at least one cell.
     """
     df = gpd.read_parquet(pq_in).reset_index()
     if spatial_sort_col != "none":
         df = df.drop(columns=[spatial_sort_col])
     if df.empty:
-        # Input is empty, nothing to convert
-        return None
+        return np.array([])
 
     # DGGS specific conversion
     df = indexer.polyfill(df, resolution)
 
     if df.empty:
-        # Conversion resulted in empty output (e.g. large cell, small feature)
-        return None
+        # e.g. features smaller than a cell at this resolution
+        return np.array([])
 
     df.index.rename(f"{indexer.dggs}_{resolution:02}", inplace=True)
 
@@ -491,10 +493,10 @@ def _polyfill(
     df.to_parquet(
         PurePath(output_directory, pq_in.name), engine="auto", compression=compression
     )
-    return None
+    return df[id_col].unique()
 
 
-def _polyfill_star(args) -> None:
+def _polyfill_star(args) -> np.ndarray:
     return _polyfill(*args)
 
 
@@ -739,6 +741,14 @@ def _clean_geometries(df: gpd.GeoDataFrame, indexer: VectorIndexer) -> gpd.GeoDa
     return df
 
 
+def _mp_context() -> multiprocessing.context.BaseContext:
+    """Never fork: the parent is multi-threaded by the time the pool starts."""
+    methods = multiprocessing.get_all_start_methods()
+    return multiprocessing.get_context(
+        "forkserver" if "forkserver" in methods else "spawn"
+    )
+
+
 def _run_dggs_indexing(
     indexer: VectorIndexer,
     filepaths: list,
@@ -748,7 +758,8 @@ def _run_dggs_indexing(
     output_dir: str,
     compression: str,
     processes: int,
-) -> None:
+    id_col: str,
+) -> set:
     LOGGER.debug("DGGS indexing by spatial partitions with resolution: %d", resolution)
     args = [
         (
@@ -759,19 +770,24 @@ def _run_dggs_indexing(
             parent_res,
             output_dir,
             compression,
+            id_col,
         )
         for filepath in filepaths
     ]
-    with ProcessPoolExecutor(max_workers=max(1, processes)) as executor:
+    indexed_ids: set = set()
+    with ProcessPoolExecutor(
+        max_workers=max(1, processes), mp_context=_mp_context()
+    ) as executor:
         futures = {executor.submit(_polyfill_star, arg): arg for arg in args}
         for future in tqdm(
             as_completed(futures), total=len(futures), desc="DGGS indexing"
         ):
             try:
-                future.result()
+                indexed_ids.update(future.result())
             except Exception as e:
                 LOGGER.error(f"Task failed with {e}")
                 raise e
+    return indexed_ids
 
 
 def index(
@@ -818,6 +834,7 @@ def index(
         df, dggs, resolution, cut_crs, cut_threshold
     )
     df = _prepare_dataframe(df, id_field, keep_attributes)
+    features_in = set(df.index)
     df = _run_bisection(df, cut_threshold, processes)
     df = _clean_geometries(df, indexer)
 
@@ -837,7 +854,7 @@ def index(
         filepaths = [f.absolute() for f in Path(tmpdir).glob("*")]
 
         with tempfile.TemporaryDirectory(suffix=".parquet") as tmpdir2:
-            _run_dggs_indexing(
+            indexed_ids = _run_dggs_indexing(
                 indexer,
                 filepaths,
                 spatial_sort_col,
@@ -846,7 +863,16 @@ def index(
                 tmpdir2,
                 compression,
                 processes,
+                id_field or "fid",
             )
+            dropped = features_in - indexed_ids
+            if dropped:
+                LOGGER.warning(
+                    "%d of %d features produced no cells at resolution %s and were omitted",
+                    len(dropped),
+                    len(features_in),
+                    resolution,
+                )
             if not any(Path(tmpdir2).glob("*.parquet")):
                 LOGGER.warning(
                     "No features were indexed (resolution %s may be too coarse for the input). Nothing to write; exiting.",

--- a/vector2dggs/constants.py
+++ b/vector2dggs/constants.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import tempfile
-import warnings
 from enum import StrEnum, unique
 
 MIN_H3, MAX_H3 = 0, 15
@@ -209,7 +208,3 @@ DEFAULTS = {
     "tempdir": tempfile.tempdir,
     "geo": GeoOutputMode.NONE.value,
 }
-
-warnings.filterwarnings(
-    "ignore"
-)  # This is to filter out the polyfill warnings when rows failed to get indexed at a resolution, can be commented out to find missing rows

--- a/vector2dggs/indexers/rhpvectorindexer.py
+++ b/vector2dggs/indexers/rhpvectorindexer.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Iterable
 from itertools import product
 
@@ -16,6 +17,11 @@ from rhppandas.util.const import COLUMNS
 from shapely.geometry import Point, Polygon
 
 from vector2dggs.indexers.vectorindexer import VectorIndexer
+
+# upstream fix pending; fires per geometry, flooding CLI output
+warnings.filterwarnings(
+    "ignore", message="WARNING: Implementation of linetrace is incomplete"
+)
 
 
 class RHPVectorIndexer(VectorIndexer):


### PR DESCRIPTION
Fixes #133, fixes #134.

**Fork context (#133):** the indexing `ProcessPoolExecutor` forked a multi-threaded parent (dask threads, tqdm, GDAL) — a genuine deadlock class, warned per-fork on Python 3.12 and defaulted away in 3.14. The pool now uses an explicit `forkserver` context (`spawn` where unavailable), scoped to the pool rather than set process-wide.

**Warnings and silent drops (#134):** the process-wide `warnings.filterwarnings("ignore")` at import time is removed — it hid the fork warning and everything else from CLI users. The rhealpixdggs "linetrace is incomplete" warning keeps a targeted filter (fires per geometry; upstream fix in progress). And features whose geometry produces no cells at the target resolution — previously dropped with no signal at all — are now reported: `N of M features produced no cells at resolution R and were omitted`.

**Tests** (written first): the pool context must not be `fork`; a two-feature input where one feature is sub-cell-sized must log `1 of 2 features produced no cells`.

Note: non-fork pool startup adds real time to the test suite (~3:20 → ~5:40 locally, one pool per CLI invocation × ~150 invocations); production runs start one pool, so the cost there is negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Benchmarked on real national data (h3 r9, default cutting): 17.1s under forkserver vs 19.2s fork baseline — no production cost. Known edge: scripts piped via stdin (`python - <<EOF`) can't use a non-fork pool (no importable `__main__`); script files, notebooks, and the CLI are unaffected.
