### PR TITLE
Library index() validates compaction requirements and defaults compact off

### DIFF
--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -1,5 +1,6 @@
 import tempfile
 import warnings
+from pathlib import Path
 from unittest import TestCase
 
 import click
@@ -132,6 +133,54 @@ class TestErrors(TestCase):
     def test_unknown_dggs_raises(self):
         with self.assertRaises(ValueError):
             indexer_instance("not_a_real_dggs")
+
+
+class TestIndexCompactionDefaults(TestCase):
+    """Library API: index() must validate compaction requirements itself."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        df = gpd.GeoDataFrame(
+            {
+                "geometry": [
+                    Polygon(
+                        [(174.7, -41.3), (174.9, -41.3), (174.9, -41.2), (174.7, -41.2)]
+                    )
+                ]
+            },
+            crs=4326,
+        )
+        self.src = f"{self._tmp.name}/in.gpkg"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            df.to_file(self.src, layer="x")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _index(self, **kwargs):
+        return common.index(
+            "h3",
+            self.src,
+            f"{self._tmp.name}/out.pq",
+            7,
+            None,
+            False,
+            50,
+            "none",
+            0.0,
+            1,
+            layer="x",
+            **kwargs,
+        )
+
+    def test_compact_without_id_field_raises_idfielderror(self):
+        with self.assertRaises(common.IdFieldError):
+            self._index(compact=True)
+
+    def test_compaction_defaults_off(self):
+        out = self._index()
+        self.assertTrue(any(Path(out).rglob("*.parquet")))
 
 
 class TestOverwriteRequired(TestRunthrough):

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -27,6 +27,10 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.errors import TestErrors as TestErrors
 with contextlib.suppress(ImportError):
+    from .classes.errors import (
+        TestIndexCompactionDefaults as TestIndexCompactionDefaults,
+    )
+with contextlib.suppress(ImportError):
     from .classes.errors import TestOverwriteRequired as TestOverwriteRequired
 with contextlib.suppress(ImportError):
     from .classes.katana import TestKatana as TestKatana

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -809,11 +809,12 @@ def index(
     geom_col: str = "geom",
     geo: str = const.GeoOutputMode.NONE.value,
     overwrite: bool = False,
-    compact: bool = True,
+    compact: bool = False,
 ) -> Path | str:
     """
     Performs multi-threaded DGGS indexing on geometries (including multipart and collections).
     """
+    check_compaction_requirements(compact, id_field)
     indexer = idxfactory.indexer_instance(dggs)
     parent_res = get_parent_res(dggs, parent_res, resolution)
 


### PR DESCRIPTION
Fixes #136.

`common.index()` now defaults `compact=False` (matching the CLI flag) and runs `check_compaction_requirements()` itself, so a library caller requesting compaction without an `id_field` gets `IdFieldError` up front rather than a `TypeError` from `groupby(None)` after the whole indexing pipeline has run.

CLI behaviour is unchanged: it already defaulted the flag off and performed the same check before calling `index()`.

Tests: `TestIndexCompactionDefaults` covers both the fail-fast error and that a default call (no `compact`, no `id_field`) completes and writes output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)