### PR TITLE
Per-test output directories; run test suite in parallel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Run tests
         shell: bash -el {0}
-        run: poetry run pytest tests/
+        run: poetry run pytest -n auto tests/

--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ Tests are included. Some tests (covering the PostgreSQL/PostGIS input path) spin
 To run them, activate the Poetry environment first (`eval "$(poetry env activate)"`), then run:
 
 ```bash
-python tests/test_vector2dggs.py
+python -m pytest -n auto tests/
 ```
 
 Or without activating the shell:
 
 ```bash
-poetry run python tests/test_vector2dggs.py
+poetry run pytest -n auto tests/
 ```
 
 To test a specific DGGS:

--- a/poetry.lock
+++ b/poetry.lock
@@ -680,6 +680,21 @@ files = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec"},
+    {file = "execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "fonttools"
 version = "4.63.0"
 description = "Tools to manipulate font files"
@@ -2339,6 +2354,27 @@ pygments = ">=2.7.2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -3398,4 +3434,4 @@ s2 = ["s2geometry"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "c127b778f01d9f162b6d3686c1240ad5355124b8fc54867533166a51c4c5df9a"
+content-hash = "ce6ae60e181edd04cf462aedec456b57099483964834cc364680b99b12543045"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ antimeridian = "^0.4.8"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9"
+pytest-xdist = "^3.6"
 twine ="^6"
 black = "^26.3.1"
 ruff = "^0.16.0"

--- a/tests/classes/antimeridian.py
+++ b/tests/classes/antimeridian.py
@@ -18,7 +18,6 @@ from vector2dggs.rHP import rhp
 from ..data.datapaths import (
     TEST_ANTIMERIDIAN_FILE_PATH,
     TEST_ANTIMERIDIAN_LAYER_NAME,
-    TEST_OUTPUT_PATH,
 )
 from .base import TestRunthrough, skip_unless_backend
 
@@ -72,15 +71,17 @@ class TestAntimeridian(TestRunthrough):
         h3(
             [
                 TEST_ANTIMERIDIAN_FILE_PATH,
-                str(TEST_OUTPUT_PATH),
+                str(self.output_path),
                 "--layer",
                 TEST_ANTIMERIDIAN_LAYER_NAME,
                 "-r",
                 "4",
+                "-t",
+                "1",
             ],
             standalone_mode=False,
         )
-        files = sorted(TEST_OUTPUT_PATH.rglob("*.parquet"))
+        files = sorted(self.output_path.rglob("*.parquet"))
         self.assertTrue(files, "No parquet files written")
 
         cell_ids = set()
@@ -100,15 +101,17 @@ class TestAntimeridian(TestRunthrough):
         rhp(
             [
                 TEST_ANTIMERIDIAN_FILE_PATH,
-                str(TEST_OUTPUT_PATH),
+                str(self.output_path),
                 "--layer",
                 TEST_ANTIMERIDIAN_LAYER_NAME,
                 "-r",
                 "4",
+                "-t",
+                "1",
             ],
             standalone_mode=False,
         )
-        files = sorted(TEST_OUTPUT_PATH.rglob("*.parquet"))
+        files = sorted(self.output_path.rglob("*.parquet"))
         self.assertTrue(files, "No parquet files written")
 
         cell_ids = set()

--- a/tests/classes/base.py
+++ b/tests/classes/base.py
@@ -1,8 +1,8 @@
+import tempfile
+from pathlib import Path
 from unittest import SkipTest, TestCase
 
 from vector2dggs.indexerfactory import indexer_instance
-
-from ..data.datapaths import TEST_OUTPUT_PATH
 
 
 def skip_unless_backend(dggs: str) -> None:
@@ -15,27 +15,12 @@ def skip_unless_backend(dggs: str) -> None:
 
 class TestRunthrough(TestCase):
     """
-    Parent class for the smoke tests. Handles temporary output files by
-    overriding the built in setup and teardown methods from TestCase. Provides
-    two new member functions to recurse through nested output folders to empty
-    them.
+    Parent class for tests that write DGGS output. Provides a per-test
+    output path inside a temporary directory, so tests are isolated from
+    each other and can run in parallel.
     """
 
     def setUp(self):
-        self.checkAndClearOutput(TEST_OUTPUT_PATH)
-
-    def tearDown(self):
-        self.checkAndClearOutput(TEST_OUTPUT_PATH)
-
-    def checkAndClearOutput(self, folder):
-        if folder.exists():
-            self.clearOutput(folder)
-            folder.rmdir()
-
-    def clearOutput(self, folder):
-        for child in folder.iterdir():
-            if child.is_dir():
-                self.clearOutput(child)
-                child.rmdir()
-            else:
-                child.unlink()
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.output_path = Path(tmp.name) / "output"

--- a/tests/classes/compaction_pipeline.py
+++ b/tests/classes/compaction_pipeline.py
@@ -7,7 +7,7 @@ import pandas as pd
 from vector2dggs.h3 import h3
 from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer
 
-from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME, TEST_OUTPUT_PATH
+from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME
 from .base import TestRunthrough
 
 
@@ -45,7 +45,7 @@ class TestCompactionAcrossPartitions(TestRunthrough):
         h3(
             [
                 TEST_FILE_PATH,
-                str(TEST_OUTPUT_PATH),
+                str(self.output_path),
                 "--layer",
                 TEST_LAYER_NAME,
                 "-r",
@@ -59,11 +59,13 @@ class TestCompactionAcrossPartitions(TestRunthrough):
                 "-ch",
                 "10",
                 "-co",
+                "-t",
+                "1",
             ],
             standalone_mode=False,
         )
 
-        df = pd.read_parquet(TEST_OUTPUT_PATH)
+        df = pd.read_parquet(self.output_path)
         cells_by_feature: dict[str, set[str]] = {}
         for cell, feature_id in set(zip(df.index, df["LCDB_UID"], strict=True)):
             cells_by_feature.setdefault(feature_id, set()).add(cell)

--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -11,15 +11,12 @@ from vector2dggs import common
 from vector2dggs.h3 import h3
 from vector2dggs.indexerfactory import indexer_instance
 
-from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME, TEST_OUTPUT_PATH
+from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME
 from .base import TestRunthrough
 
 
-class TestErrors(TestCase):
-    """
-    Error-path unit tests that raise before touching the filesystem,
-    so no output cleanup is needed.
-    """
+class TestErrors(TestRunthrough):
+    """Error-path unit tests that raise before writing any output."""
 
     def test_crsless_input_raises_clear_error(self):
         naive = gpd.GeoDataFrame(
@@ -56,7 +53,7 @@ class TestErrors(TestCase):
             h3(
                 [
                     TEST_FILE_PATH,
-                    str(TEST_OUTPUT_PATH),
+                    str(self.output_path),
                     "--layer",
                     TEST_LAYER_NAME,
                     "-r",
@@ -72,7 +69,7 @@ class TestErrors(TestCase):
             h3(
                 [
                     TEST_FILE_PATH,
-                    str(TEST_OUTPUT_PATH),
+                    str(self.output_path),
                     "--layer",
                     TEST_LAYER_NAME,
                     "-r",
@@ -88,7 +85,7 @@ class TestErrors(TestCase):
             h3(
                 [
                     TEST_FILE_PATH,
-                    str(TEST_OUTPUT_PATH),
+                    str(self.output_path),
                     "--layer",
                     TEST_LAYER_NAME,
                     "-r",
@@ -104,7 +101,7 @@ class TestErrors(TestCase):
             h3(
                 [
                     TEST_FILE_PATH,
-                    str(TEST_OUTPUT_PATH),
+                    str(self.output_path),
                     "--layer",
                     TEST_LAYER_NAME,
                     "-r",
@@ -120,7 +117,7 @@ class TestErrors(TestCase):
             h3(
                 [
                     TEST_FILE_PATH,
-                    str(TEST_OUTPUT_PATH),
+                    str(self.output_path),
                     "--layer",
                     TEST_LAYER_NAME,
                     "-r",
@@ -190,11 +187,13 @@ class TestOverwriteRequired(TestRunthrough):
         h3(
             [
                 TEST_FILE_PATH,
-                str(TEST_OUTPUT_PATH),
+                str(self.output_path),
                 "--layer",
                 TEST_LAYER_NAME,
                 "-r",
                 "8",
+                "-t",
+                "1",
             ],
             standalone_mode=False,
         )
@@ -202,7 +201,7 @@ class TestOverwriteRequired(TestRunthrough):
             h3(
                 [
                     TEST_FILE_PATH,
-                    str(TEST_OUTPUT_PATH),
+                    str(self.output_path),
                     "--layer",
                     TEST_LAYER_NAME,
                     "-r",

--- a/tests/classes/output_validation.py
+++ b/tests/classes/output_validation.py
@@ -4,7 +4,7 @@ import pyarrow.parquet as pq
 
 from vector2dggs.h3 import h3
 
-from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME, TEST_OUTPUT_PATH
+from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME
 from .base import TestRunthrough, skip_unless_backend
 
 
@@ -21,7 +21,7 @@ class TestOutputValidation(TestRunthrough):
         super().setUpClass()
 
     def _parquet_files(self):
-        files = sorted(TEST_OUTPUT_PATH.rglob("*.parquet"))
+        files = sorted(self.output_path.rglob("*.parquet"))
         self.assertTrue(files, "No parquet files written to output")
         return files
 
@@ -29,11 +29,13 @@ class TestOutputValidation(TestRunthrough):
         h3(
             [
                 TEST_FILE_PATH,
-                str(TEST_OUTPUT_PATH),
+                str(self.output_path),
                 "--layer",
                 TEST_LAYER_NAME,
                 "-r",
                 "8",
+                "-t",
+                "1",
                 *extra_args,
             ],
             standalone_mode=False,
@@ -42,7 +44,7 @@ class TestOutputValidation(TestRunthrough):
     def test_partition_dirs_named_by_parent_res(self):
         """Hive partition directories are named h3_02=<token>."""
         self._run_h3()
-        dirs = [d for d in TEST_OUTPUT_PATH.iterdir() if d.is_dir()]
+        dirs = [d for d in self.output_path.iterdir() if d.is_dir()]
         self.assertTrue(dirs, "No partition directories in output")
         for d in dirs:
             self.assertTrue(
@@ -53,7 +55,7 @@ class TestOutputValidation(TestRunthrough):
     def test_explicit_parent_res_reflected_in_dirs(self):
         """--parent-res 3 produces h3_03=… partition directories."""
         self._run_h3(("-pr", "3"))
-        dirs = [d for d in TEST_OUTPUT_PATH.iterdir() if d.is_dir()]
+        dirs = [d for d in self.output_path.iterdir() if d.is_dir()]
         self.assertTrue(dirs, "No partition directories in output")
         for d in dirs:
             self.assertTrue(

--- a/tests/classes/postgis.py
+++ b/tests/classes/postgis.py
@@ -6,7 +6,7 @@ import sqlalchemy
 
 from vector2dggs.h3 import h3
 
-from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME, TEST_OUTPUT_PATH
+from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME
 from .base import TestRunthrough
 
 
@@ -56,17 +56,19 @@ class TestPostGIS(TestRunthrough):
         h3(
             [
                 self.connection_url,
-                str(TEST_OUTPUT_PATH),
+                str(self.output_path),
                 "--layer",
                 self.TABLE_NAME,
                 "-g",
                 "geometry",
                 "-r",
                 "8",
+                "-t",
+                "1",
             ],
             standalone_mode=False,
         )
-        files = sorted(TEST_OUTPUT_PATH.rglob("*.parquet"))
+        files = sorted(self.output_path.rglob("*.parquet"))
         self.assertTrue(files, "No parquet files written from PostGIS input")
         table = pq.read_table(files[0])
         self.assertIn("h3_08", table.schema.names)
@@ -76,18 +78,20 @@ class TestPostGIS(TestRunthrough):
         h3(
             [
                 self.connection_url,
-                str(TEST_OUTPUT_PATH),
+                str(self.output_path),
                 "--layer",
                 self.TABLE_NAME,
                 "-g",
                 "geometry",
                 "-r",
                 "8",
+                "-t",
+                "1",
                 "-k",
             ],
             standalone_mode=False,
         )
-        files = sorted(TEST_OUTPUT_PATH.rglob("*.parquet"))
+        files = sorted(self.output_path.rglob("*.parquet"))
         self.assertTrue(files, "No parquet files written from PostGIS input")
         table = pq.read_table(files[0])
         self.assertIn("Name_2018", table.schema.names)
@@ -97,7 +101,7 @@ class TestPostGIS(TestRunthrough):
         h3(
             [
                 self.connection_url,
-                str(TEST_OUTPUT_PATH),
+                str(self.output_path),
                 "--layer",
                 self.TABLE_NAME,
                 "-g",
@@ -106,10 +110,12 @@ class TestPostGIS(TestRunthrough):
                 "LCDB_UID",
                 "-r",
                 "8",
+                "-t",
+                "1",
             ],
             standalone_mode=False,
         )
-        files = sorted(TEST_OUTPUT_PATH.rglob("*.parquet"))
+        files = sorted(self.output_path.rglob("*.parquet"))
         self.assertTrue(files, "No parquet files written from PostGIS input")
         table = pq.read_table(files[0])
         self.assertIn("LCDB_UID", table.schema.names)

--- a/tests/classes/runthrough.py
+++ b/tests/classes/runthrough.py
@@ -16,7 +16,6 @@ from ..data.datapaths import (
     TEST_LAYER_NAME,
     TEST_LINESTRING_FILE_PATH,
     TEST_LINESTRING_LAYER_NAME,
-    TEST_OUTPUT_PATH,
     TEST_POINT_FILE_PATH,
     TEST_POINT_LAYER_NAME,
 )
@@ -53,15 +52,25 @@ class RunthroughScenarios:
     def _run(self, dataset, res, *extra):
         path, layer, _, _ = dataset
         self.COMMAND(
-            [path, str(TEST_OUTPUT_PATH), "--layer", layer, "-r", res, *extra],
+            [
+                path,
+                str(self.output_path),
+                "--layer",
+                layer,
+                "-r",
+                res,
+                "-t",
+                "1",
+                *extra,
+            ],
             standalone_mode=False,
         )
 
     def _assert_output(self, res, id_col="fid", attr_col=None, geo=None, compact=False):
-        files = sorted(TEST_OUTPUT_PATH.rglob("*.parquet"))
+        files = sorted(self.output_path.rglob("*.parquet"))
         self.assertTrue(files, "no parquet output written")
 
-        df = pd.read_parquet(TEST_OUTPUT_PATH)
+        df = pd.read_parquet(self.output_path)
         self.assertGreater(len(df), 0, "output has no rows")
 
         dggs_col = f"{self.DGGS}_{int(res):02}"
@@ -80,7 +89,7 @@ class RunthroughScenarios:
             self.assertEqual(resolutions, {int(res)})
 
         # hive partition dirs carry the parent cell
-        partition_dirs = [d for d in TEST_OUTPUT_PATH.iterdir() if d.is_dir()]
+        partition_dirs = [d for d in self.output_path.iterdir() if d.is_dir()]
         self.assertTrue(
             all(d.name.startswith(f"{parent_col}=") for d in partition_dirs)
         )

--- a/tests/data/datapaths.py
+++ b/tests/data/datapaths.py
@@ -4,7 +4,6 @@ DATA_DIR = Path(__file__).resolve().parent
 
 TEST_FILE_PATH = str(DATA_DIR / "se-island.gpkg")
 TEST_LAYER_NAME = "se_island"
-TEST_OUTPUT_PATH = DATA_DIR / "output"
 
 TEST_LINESTRING_FILE_PATH = str(DATA_DIR / "se-island-contours.gpkg")
 TEST_LINESTRING_LAYER_NAME = "contours"


### PR DESCRIPTION
Fixes #138.

Tests previously shared the hard-coded `tests/data/output` directory, with `setUp`/`tearDown` both deleting it — tests could not run concurrently, and a failing test's output was destroyed before it could be inspected. Changes:

- `TestRunthrough` now provides a per-test `self.output_path` inside a `TemporaryDirectory`; all test classes use it, and the shared `TEST_OUTPUT_PATH` constant is gone
- test CLI invocations pin `-t 1`: the fixtures are small enough that a full worker pool adds startup cost without useful parallelism
- `pytest-xdist` added as a dev dependency; CI runs `pytest -n auto`

Timings on an 8-core machine, 152 tests:

| configuration | wall time |
|---|---|
| main (serial, default `-t`) | 5:39 |
| this branch, serial | 7:35 |
| this branch, `-n auto` | 4:13 |

The serial number regresses because of `-t 1` — kept anyway since serial runs aren't the intended mode, and `-t 1` avoids oversubscription (N pytest workers × N pool workers) under xdist. CPU utilisation under `-n auto` is only ~40%, so the remaining wall time is dominated by a few long tests on the critical path, not core starvation. CI runners have fewer cores, so expect a smaller (but still real) improvement there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)