### PR TITLE
S2 polyfill returns string tokens

### DIFF
--- a/tests/classes/polyfill_contract.py
+++ b/tests/classes/polyfill_contract.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+
+import geopandas as gpd
+from shapely.geometry import LineString, Point, Polygon
+
+from vector2dggs.indexerfactory import indexer_instance
+
+from .base import skip_unless_backend
+
+RES = {"h3": 8, "s2": 13, "a5": 17, "rhp": 8, "geohash": 6}
+
+
+class TestPolyfillTokenContract(TestCase):
+    """polyfill() must index by string cell ids for every backend."""
+
+    def _assert_str_index(self, dggs):
+        skip_unless_backend(dggs)
+        # matches the shape polyfill() receives in the pipeline: feature id
+        # as a column, plain RangeIndex
+        df = gpd.GeoDataFrame(
+            {
+                "fid": [1, 2, 3],
+                "geometry": [
+                    Polygon(
+                        [
+                            (174.70, -41.30),
+                            (174.75, -41.30),
+                            (174.75, -41.25),
+                            (174.70, -41.25),
+                        ]
+                    ),
+                    LineString([(174.70, -41.30), (174.75, -41.25)]),
+                    Point(174.72, -41.28),
+                ],
+            },
+            crs=4326,
+        )
+        result = indexer_instance(dggs).polyfill(df, RES[dggs])
+        self.assertGreater(len(result), 0)
+        non_str = {type(c).__name__ for c in result.index if not isinstance(c, str)}
+        self.assertFalse(non_str, f"non-str cell ids in index: {non_str}")
+
+    def test_h3(self):
+        self._assert_str_index("h3")
+
+    def test_s2(self):
+        self._assert_str_index("s2")
+
+    def test_a5(self):
+        self._assert_str_index("a5")
+
+    def test_rhp(self):
+        self._assert_str_index("rhp")
+
+    def test_geohash(self):
+        self._assert_str_index("geohash")

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -41,6 +41,10 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.output_validation import TestOutputValidation as TestOutputValidation
 with contextlib.suppress(ImportError):
+    from .classes.polyfill_contract import (
+        TestPolyfillTokenContract as TestPolyfillTokenContract,
+    )
+with contextlib.suppress(ImportError):
     from .classes.postgis import TestPostGIS as TestPostGIS
 with contextlib.suppress(ImportError):
     from .classes.write_limits import TestRaiseRlimitNofile as TestRaiseRlimitNofile

--- a/vector2dggs/indexers/s2vectorindexer.py
+++ b/vector2dggs/indexers/s2vectorindexer.py
@@ -35,7 +35,7 @@ class S2VectorIndexer(VectorIndexer):
         geom_col = df.geometry.name
         df = df.copy()
         df["s2index"] = df.geometry.apply(
-            lambda geom: self.cell_ids_from_linestring(geom, level)
+            lambda geom: self.tokens_from_linestring(geom, level)
         )
         result = (
             df.drop(columns=[geom_col])
@@ -49,7 +49,7 @@ class S2VectorIndexer(VectorIndexer):
         geom_col = df.geometry.name
         df = df.copy()
         df["s2index"] = df.geometry.apply(
-            lambda geom: self.cell_id_from_point(geom, level)
+            lambda geom: self.token_from_point(geom, level)
         )
         result = df.drop(columns=[geom_col]).set_index("s2index")
         return pd.DataFrame(result)
@@ -58,13 +58,9 @@ class S2VectorIndexer(VectorIndexer):
         """
         Implementation of abstract function.
         """
-
-        # NB also converts the index to S2 cell tokens
-        index_series = df.index.to_series().astype(object)
-        df[f"s2_{parent_level:02}"] = index_series.map(
-            lambda cell_id: cell_id.parent(parent_level).ToToken()
+        df[f"s2_{parent_level:02}"] = df.index.to_series().map(
+            lambda token: S2.S2CellId.FromToken(token).parent(parent_level).ToToken()
         )
-        df.index = index_series.map(lambda cell_id: cell_id.ToToken())
         return df
 
     def compaction(
@@ -102,7 +98,7 @@ class S2VectorIndexer(VectorIndexer):
 
         def generate_covering(
             geom: Polygon, level: int, centroid_inside: bool = True
-        ) -> set[S2.S2CellId]:
+        ) -> set[str]:
             geom = force_2d(geom)
             # Prepare loops: first the exterior loop, then the interior loops
             loops = []
@@ -151,7 +147,7 @@ class S2VectorIndexer(VectorIndexer):
             else:
                 covering = set(raw_covering)
 
-            return covering
+            return {cell.ToToken() for cell in covering}
 
         df["s2index"] = df["geometry"].apply(
             lambda geom: generate_covering(geom, level)
@@ -204,9 +200,7 @@ class S2VectorIndexer(VectorIndexer):
         cell_center = S2.S2Cell(cell).GetCenter()
         return polygon.Contains(cell_center)
 
-    def cell_ids_from_linestring(
-        self, linestring: LineString, level: int
-    ) -> list[S2.S2CellId]:
+    def tokens_from_linestring(self, linestring: LineString, level: int) -> list[str]:
         """
         Not a part of the interface provided by VectorIndexer.
         """
@@ -221,16 +215,16 @@ class S2VectorIndexer(VectorIndexer):
         coverer.set_min_level(level)
         coverer.set_max_level(level)
 
-        return coverer.GetCovering(polyline)
+        return [cell.ToToken() for cell in coverer.GetCovering(polyline)]
 
-    def cell_id_from_point(self, geom: Point, level: int) -> S2.S2CellId:
+    def token_from_point(self, geom: Point, level: int) -> str:
         """
-        Convert a point geometry to an S2 cell at the specified level.
+        Convert a point geometry to an S2 cell token at the specified level.
 
         Not a part of the interface provided by VectorIndexer.
         """
         latlng = S2.S2LatLng.FromDegrees(geom.y, geom.x)
-        return S2.S2CellId(latlng).parent(level)
+        return S2.S2CellId(latlng).parent(level).ToToken()
 
     def compact_tokens(self, tokens: Iterable[str]) -> set[str]:
         """


### PR DESCRIPTION
Fixes #140.

The S2 `_polyfill_*` helpers now convert cell IDs to string tokens themselves, matching the `str` type hints on `VectorIndexer` and the behaviour of every other backend. `secondary_index` now derives the parent token from the cell token, rather than silently doubling as the object-to-token conversion step. Output is unchanged.

Adds a contract test asserting `polyfill()` indexes by strings for all five backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)