### PR TITLE
Input dispatch by capability, not URL-scheme sniffing

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3434,4 +3434,4 @@ s2 = ["s2geometry"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "ce6ae60e181edd04cf462aedec456b57099483964834cc364680b99b12543045"
+content-hash = "94c370a020e3c181aee97a0ae54269d44000126660283711beeb589d9411974e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 python = "^3.11"
 gdal = ">=3.13.1"
 geopandas = "^1.1.2"
+pyogrio = "^0.13"
 dask-geopandas = "^0.5"
 dask = "^2025.1"
 click = "^8.1.7"

--- a/tests/classes/input_dispatch.py
+++ b/tests/classes/input_dispatch.py
@@ -1,0 +1,40 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+from vector2dggs import common
+
+
+class TestInputDispatch(TestCase):
+    """db_conn_and_input_path: file if it exists, database if sqlalchemy can
+    engine it, remote pass-through if it has a scheme, else FileNotFoundError."""
+
+    def test_existing_file_returned_as_path(self):
+        with tempfile.NamedTemporaryFile(suffix=".gpkg") as f:
+            con, path = common.db_conn_and_input_path(f.name)
+        self.assertIsNone(con)
+        self.assertEqual(path, Path(f.name))
+
+    def test_postgres_url_returns_engine(self):
+        con, path = common.db_conn_and_input_path(
+            "postgresql+psycopg2://user:pw@localhost:1/db"
+        )
+        self.assertIsNotNone(con)
+
+    def test_windows_drive_letter_path_not_treated_as_database(self):
+        with self.assertRaises(FileNotFoundError):
+            common.db_conn_and_input_path(r"C:\data\input.gpkg")
+
+    def test_remote_uri_passed_through(self):
+        con, path = common.db_conn_and_input_path("https://example.com/data.gpkg")
+        self.assertIsNone(con)
+        self.assertEqual(path, "https://example.com/data.gpkg")
+
+    def test_file_uri_passed_through(self):
+        con, path = common.db_conn_and_input_path("file:///nonexistent/data.gpkg")
+        self.assertIsNone(con)
+        self.assertEqual(path, "file:///nonexistent/data.gpkg")
+
+    def test_nonexistent_plain_path_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            common.db_conn_and_input_path("/nonexistent/data.gpkg")

--- a/tests/classes/input_dispatch.py
+++ b/tests/classes/input_dispatch.py
@@ -1,13 +1,19 @@
 import tempfile
+import zipfile
 from pathlib import Path
 from unittest import TestCase
 
+from pyogrio.errors import DataSourceError
+
 from vector2dggs import common
+
+from ..data.datapaths import TEST_FILE_PATH
 
 
 class TestInputDispatch(TestCase):
-    """db_conn_and_input_path: file if it exists, database if sqlalchemy can
-    engine it, remote pass-through if it has a scheme, else FileNotFoundError."""
+    """db_conn_and_input_path: file if it exists on disk, database if
+    sqlalchemy can engine it, anything else GDAL can open is passed through;
+    GDAL's DataSourceError propagates otherwise."""
 
     def test_existing_file_returned_as_path(self):
         with tempfile.NamedTemporaryFile(suffix=".gpkg") as f:
@@ -21,20 +27,24 @@ class TestInputDispatch(TestCase):
         )
         self.assertIsNotNone(con)
 
+    def test_gdal_virtual_path_passed_through(self):
+        with tempfile.TemporaryDirectory() as d:
+            zip_path = f"{d}/data.zip"
+            with zipfile.ZipFile(zip_path, "w") as z:
+                z.write(TEST_FILE_PATH, arcname="se-island.gpkg")
+            vsi = f"/vsizip/{zip_path}/se-island.gpkg"
+            con, path = common.db_conn_and_input_path(vsi)
+            self.assertIsNone(con)
+            self.assertEqual(path, vsi)
+
     def test_windows_drive_letter_path_not_treated_as_database(self):
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(DataSourceError):
             common.db_conn_and_input_path(r"C:\data\input.gpkg")
 
-    def test_remote_uri_passed_through(self):
-        con, path = common.db_conn_and_input_path("https://example.com/data.gpkg")
-        self.assertIsNone(con)
-        self.assertEqual(path, "https://example.com/data.gpkg")
-
-    def test_file_uri_passed_through(self):
-        con, path = common.db_conn_and_input_path("file:///nonexistent/data.gpkg")
-        self.assertIsNone(con)
-        self.assertEqual(path, "file:///nonexistent/data.gpkg")
-
     def test_nonexistent_plain_path_raises(self):
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(DataSourceError):
             common.db_conn_and_input_path("/nonexistent/data.gpkg")
+
+    def test_nonexistent_uri_raises(self):
+        with self.assertRaises(DataSourceError):
+            common.db_conn_and_input_path("file:///nonexistent/data.gpkg")

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -33,6 +33,8 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.errors import TestOverwriteRequired as TestOverwriteRequired
 with contextlib.suppress(ImportError):
+    from .classes.input_dispatch import TestInputDispatch as TestInputDispatch
+with contextlib.suppress(ImportError):
     from .classes.katana import TestKatana as TestKatana
 with contextlib.suppress(ImportError):
     from .classes.linetrace import (

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -8,7 +8,6 @@ import tempfile
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from pathlib import Path, PurePath
 from types import ModuleType
-from urllib.parse import urlparse
 from uuid import uuid4
 
 import antimeridian
@@ -28,6 +27,8 @@ import shapely
 import shapely.affinity
 import sqlalchemy
 from shapely.geometry import GeometryCollection
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError, NoSuchModuleError
 from tqdm import tqdm
 from tqdm.dask import TqdmCallback
 
@@ -94,27 +95,25 @@ def validate_compression(ctx, param, value: str) -> str:
 def db_conn_and_input_path(
     vector_input: str | Path,
 ) -> tuple[SQLConnectionType | None, str | Path]:
-    con: SQLConnectionType | None = None
-    scheme: str = urlparse(str(vector_input)).scheme
+    if Path(vector_input).exists():
+        return (None, Path(vector_input))
 
-    if bool(scheme) and scheme != "file":
-        # Assume database connection
-        con = sqlalchemy.create_engine(str(vector_input))
-
-    elif not Path(vector_input).exists():
-        if not scheme:
-            LOGGER.error(
-                f"Input vector {vector_input} does not exist, and is not recognised as a remote URI"
-            )
-            raise FileNotFoundError(
-                errno.ENOENT, os.strerror(errno.ENOENT), vector_input
-            )
-        vector_input = str(vector_input)
-
+    try:
+        url = make_url(str(vector_input))
+        url.get_dialect()
+    except (ArgumentError, NoSuchModuleError):
+        pass
     else:
-        vector_input = Path(vector_input)
+        return (sqlalchemy.create_engine(url), vector_input)
 
-    return (con, vector_input)
+    if "://" in str(vector_input):
+        # e.g. https:// or s3://; GDAL may be able to read it
+        return (None, str(vector_input))
+
+    LOGGER.error(
+        f"Input vector {vector_input} does not exist, and is not recognised as a remote URI"
+    )
+    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), vector_input)
 
 
 def resolve_output_path(output_directory: str | Path, overwrite: bool) -> str | Path:

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -1,4 +1,3 @@
-import errno
 import json
 import logging
 import multiprocessing
@@ -22,6 +21,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as pa_ds
 import pyarrow.parquet as pq
+import pyogrio
 import pyproj
 import shapely
 import shapely.affinity
@@ -106,14 +106,9 @@ def db_conn_and_input_path(
     else:
         return (sqlalchemy.create_engine(url), vector_input)
 
-    if "://" in str(vector_input):
-        # e.g. https:// or s3://; GDAL may be able to read it
-        return (None, str(vector_input))
-
-    LOGGER.error(
-        f"Input vector {vector_input} does not exist, and is not recognised as a remote URI"
-    )
-    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), vector_input)
+    # Remote URI or GDAL virtual path: raises DataSourceError if GDAL can't open it
+    pyogrio.read_info(str(vector_input))
+    return (None, str(vector_input))
 
 
 def resolve_output_path(output_directory: str | Path, overwrite: bool) -> str | Path:


### PR DESCRIPTION
Fixes #146.

`db_conn_and_input_path` now dispatches by positive checks, each verified by the subsystem that will handle the input:

1. an input that exists on disk is a file;
2. an input that sqlalchemy can parse (`make_url`) and resolve a dialect for (`get_dialect()`) is a database connection — exactly the inputs `create_engine` can handle;
3. anything else is probed with `pyogrio.read_info`: if GDAL can open it (remote URI, `/vsi*` virtual path) it's passed through; if not, GDAL's `DataSourceError` propagates with the specific reason (`No such file or directory`, `HTTP response code: 404`, `BucketNotFound`, …).

Previously any input whose `urlparse` scheme wasn't `file` went to `create_engine`: `C:\data\input.gpkg` (scheme `c`) crashed with an SQL URL parse error, and `https://`/`s3://` URIs crashed with `NoSuchModuleError`. `/vsi*` paths were rejected as nonexistent files. `urlparse` is no longer used.

The input is now validated *before* `resolve_output_path` creates (or, with `-o`, deletes and recreates) the output directory — so a typo'd input no longer destroys a previous run's output or poisons a retry with `FileExistsError`.

API note: a nonexistent local path now raises `pyogrio.errors.DataSourceError` rather than `FileNotFoundError`. `pyogrio` (already geopandas' IO engine) is declared as a direct dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)