### PR TITLE
Scope the geographic-CRS area warning in the antimeridian test

### DIFF
--- a/tests/classes/antimeridian.py
+++ b/tests/classes/antimeridian.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest import TestCase
 
 import geopandas as gpd
@@ -61,8 +62,12 @@ class TestAntimeridian(TestRunthrough):
         # The true area of a 200km x 200km square near the equator is
         # roughly 3.2 degrees^2; the unfixed reprojection artifact wraps the
         # "long way" around the globe instead, giving an area in the
-        # hundreds.
-        self.assertAlmostEqual(cleaned.geometry.area.sum(), 3.25, places=1)
+        # hundreds. Square degrees are the point here, so silence the
+        # geographic-CRS area warning.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            area = cleaned.geometry.area.sum()
+        self.assertAlmostEqual(area, 3.25, places=1)
 
     def test_h3_run_across_antimeridian(self):
         """H3 doesn't require the pre-split fix - it indexes this correctly


### PR DESCRIPTION
Fixes #151.

The test compares areas in square degrees on purpose (correct fixture area ≈3.25 deg² vs hundreds for the unfixed artifact), so the geopandas geographic-CRS `.area` warning is expected there. Now scoped with `warnings.catch_warnings()` around just that call; verified the test passes under `-W error::UserWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)