### PR TITLE
Close unit-test coverage gaps; remove dead geohash helpers

### DIFF
--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -1,0 +1,86 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+
+import pandas as pd
+
+import vector2dggs.constants as const
+from vector2dggs import common
+
+
+class TestGetParentRes(TestCase):
+    def test_explicit_parent_passes_through(self):
+        self.assertEqual(common.get_parent_res("h3", "5", 9), 5)
+
+    def test_default_derived_from_resolution(self):
+        self.assertEqual(
+            common.get_parent_res("h3", None, 9),
+            const.DEFAULT_DGGS_PARENT_RES["h3"](9),
+        )
+
+    def test_unknown_dggs_raises(self):
+        with self.assertRaises(RuntimeError):
+            common.get_parent_res("not_a_dggs", None, 9)
+
+
+class TestDropCondition(TestCase):
+    def test_small_drop_logs_info(self):
+        df = pd.DataFrame({"a": range(1000)})
+        with self.assertLogs(common.LOGGER, level="INFO") as logs:
+            out = common.drop_condition(df, df.index[:1], "dropping")
+        self.assertEqual(len(out), 999)
+        self.assertTrue(any(r.levelname == "INFO" for r in logs.records))
+
+    def test_large_drop_warns(self):
+        df = pd.DataFrame({"a": range(10)})
+        with self.assertLogs(common.LOGGER, level="WARNING"):
+            out = common.drop_condition(df, df.index[:5], "dropping")
+        self.assertEqual(len(out), 5)
+
+
+class TestWritePartitionGuards(TestCase):
+    def test_empty_frame_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as d:
+            n = common.write_partition(
+                pd.DataFrame(), None, Path(d), "p", "c", "snappy"
+            )
+            self.assertEqual(n, 0)
+            self.assertFalse(list(Path(d).iterdir()))
+
+    def test_missing_partition_column_raises(self):
+        df = pd.DataFrame({"c": ["a"], "x": [1]}).set_index("c")
+        with tempfile.TemporaryDirectory() as d, self.assertRaises(KeyError):
+            common.write_partition(df, None, Path(d), "p", "c", "snappy")
+
+    def test_all_null_cell_ids_write_nothing(self):
+        df = pd.DataFrame({"p": ["x"], "c": [None]})
+        with tempfile.TemporaryDirectory() as d:
+            n = common.write_partition(df, None, Path(d), "p", "c", "snappy")
+            self.assertEqual(n, 0)
+            self.assertFalse(list(Path(d).iterdir()))
+
+
+class TestCommitOutput(TestCase):
+    def test_refuses_directory_created_mid_run_without_overwrite(self):
+        with tempfile.TemporaryDirectory() as d:
+            staging = Path(d) / ".out.staging"
+            staging.mkdir()
+            (staging / "new.parquet").touch()
+            target = Path(d) / "out"
+            target.mkdir()  # appeared after validation, mid-run
+            (target / "theirs.txt").touch()
+            with self.assertRaises(FileExistsError):
+                common._commit_output(staging, target, overwrite=False)
+            self.assertTrue((target / "theirs.txt").exists())
+
+    def test_replaces_existing_with_overwrite(self):
+        with tempfile.TemporaryDirectory() as d:
+            staging = Path(d) / ".out.staging"
+            staging.mkdir()
+            (staging / "new.parquet").touch()
+            target = Path(d) / "out"
+            target.mkdir()
+            (target / "old.parquet").touch()
+            result = common._commit_output(staging, target, overwrite=True)
+            self.assertEqual([p.name for p in Path(result).iterdir()], ["new.parquet"])
+            self.assertFalse(staging.exists())

--- a/tests/classes/katana.py
+++ b/tests/classes/katana.py
@@ -1,5 +1,5 @@
-from shapely import wkt
-from shapely.geometry import Polygon
+from shapely import has_z, wkt
+from shapely.geometry import LinearRing, Polygon
 
 from vector2dggs.katana import katana
 
@@ -41,3 +41,21 @@ class TestKatana(TestRunthrough):
             self.assertLessEqual((maxx - minx) * (maxy - miny), threshold)
         # No area may be lost or duplicated by the splitting
         self.assertAlmostEqual(sum(p.area for p in parts), square.area, places=6)
+
+    def test_linearring_input_becomes_polygon(self):
+        ring = LinearRing([(0, 0), (10, 0), (10, 10), (0, 10)])
+        pieces = katana(ring, threshold=1000.0)
+        self.assertEqual([p.geom_type for p in pieces], ["Polygon"])
+
+    def test_3d_input_is_flattened(self):
+        poly = Polygon([(0, 0, 5), (10, 0, 5), (10, 10, 5), (0, 10, 5)])
+        pieces = katana(poly, threshold=30.0)
+        self.assertGreater(len(pieces), 1)
+        self.assertFalse(any(has_z(p) for p in pieces))
+
+    def test_invalid_bowtie_is_made_valid(self):
+        bowtie = Polygon([(0, 0), (10, 10), (10, 0), (0, 10)])  # self-intersecting
+        pieces = katana(bowtie, threshold=30.0)
+        self.assertTrue(all(p.is_valid for p in pieces))
+        # a bowtie's true area is the two triangles
+        self.assertAlmostEqual(sum(p.area for p in pieces), 50.0, places=6)

--- a/tests/classes/polyfill_contract.py
+++ b/tests/classes/polyfill_contract.py
@@ -8,6 +8,8 @@ from vector2dggs.indexerfactory import indexer_instance
 from .base import skip_unless_backend
 
 RES = {"h3": 8, "s2": 13, "a5": 17, "rhp": 8, "geohash": 6}
+# fine enough that multiple cell centres fall inside the test hole
+HOLE_RES = {"h3": 10, "s2": 15, "a5": 18, "rhp": 9, "geohash": 7}
 
 
 class TestPolyfillTokenContract(TestCase):
@@ -40,17 +42,39 @@ class TestPolyfillTokenContract(TestCase):
         non_str = {type(c).__name__ for c in result.index if not isinstance(c, str)}
         self.assertFalse(non_str, f"non-str cell ids in index: {non_str}")
 
+    def _assert_hole_respected(self, dggs):
+        skip_unless_backend(dggs)
+        shell = [(174.70, -41.30), (174.76, -41.30), (174.76, -41.24), (174.70, -41.24)]
+        hole = [(174.72, -41.28), (174.74, -41.28), (174.74, -41.26), (174.72, -41.26)]
+        donut = Polygon(shell, [hole])
+        # shrunk oracle: backends interpret the hole's straight edges as
+        # curves (sub-metre band), so only centres well inside the hole count
+        hole_core = Polygon(hole).buffer(-0.001)
+        df = gpd.GeoDataFrame({"fid": [1], "geometry": [donut]}, crs=4326)
+        indexer = indexer_instance(dggs)
+        result = indexer.polyfill(df, HOLE_RES[dggs])
+        self.assertGreater(len(result), 0)
+        leaked = [
+            c for c in result.index if hole_core.contains(indexer.cell_to_point(c))
+        ]
+        self.assertFalse(leaked, f"cells with centres inside the hole: {leaked[:5]}")
+
     def test_h3(self):
         self._assert_str_index("h3")
+        self._assert_hole_respected("h3")
 
     def test_s2(self):
         self._assert_str_index("s2")
+        self._assert_hole_respected("s2")
 
     def test_a5(self):
         self._assert_str_index("a5")
+        self._assert_hole_respected("a5")
 
     def test_rhp(self):
         self._assert_str_index("rhp")
+        self._assert_hole_respected("rhp")
 
     def test_geohash(self):
         self._assert_str_index("geohash")
+        self._assert_hole_respected("geohash")

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -36,6 +36,16 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.compaction import TestS2CompactionBounds as TestS2CompactionBounds
 with contextlib.suppress(ImportError):
+    from .classes.common_units import TestCommitOutput as TestCommitOutput
+with contextlib.suppress(ImportError):
+    from .classes.common_units import TestDropCondition as TestDropCondition
+with contextlib.suppress(ImportError):
+    from .classes.common_units import TestGetParentRes as TestGetParentRes
+with contextlib.suppress(ImportError):
+    from .classes.common_units import (
+        TestWritePartitionGuards as TestWritePartitionGuards,
+    )
+with contextlib.suppress(ImportError):
     from .classes.compaction_pipeline import (
         TestCompactionAcrossPartitions as TestCompactionAcrossPartitions,
     )

--- a/vector2dggs/indexers/geohashvectorindexer.py
+++ b/vector2dggs/indexers/geohashvectorindexer.py
@@ -179,27 +179,6 @@ class GeohashVectorIndexer(VectorIndexer):
             return geohash
         return geohash.ljust(desired_length, child)
 
-    def gh_children(self, geohash: str, desired_resolution: int) -> int:
-        """
-        Determine the number of children in the geohash refinement, determined by
-        the additional character levels.
-
-        Not a part of the interface provided by VectorIndexer.
-        """
-        current_resolution = len(geohash)
-        additional_length = desired_resolution - current_resolution
-        return 32**additional_length  # Each new character increases resolution by 32
-
-    def get_central_child(self, geohash: str, precision: int):
-        """
-        Return an approximate central child of the geohash.
-        NB if only an arbitrary child is needed, use get_child_geohash
-
-        Not a part of the interface provided by VectorIndexer.
-        """
-        lat, lon = decode(geohash)
-        return encode(lat, lon, precision=precision)
-
     def _polygon_to_geohashes(self, polygon: Polygon, level: int) -> set[str]:
         """
         Function to compute geohash set for one polygon geometry


### PR DESCRIPTION
Fixes #155.

From a coverage audit (88% overall) of what remained on the review's list — most previously-listed gaps had been covered by intervening PRs (input dispatch, staged output, katana threshold/blade tests, the unified writer). What was genuinely left:

- **Polygon holes were untested on every backend**, despite S2 carrying dedicated interior-ring handling (its only uncovered polyfill branch). Verified working on all five; now asserted per backend in the polyfill contract test. The hole oracle is shrunk by ~100 m because backends read the hole's straight edges as curves (sub-metre band) — a centre exactly on the hole boundary is not a leak.
- Unit tests for `get_parent_res`, `drop_condition`'s info/warning threshold, `write_partition`'s guard branches, `_commit_output`'s refusal to replace a directory that appeared mid-run, and katana's input normalisation (LinearRing, Z/M coordinates, invalid self-intersecting input).
- `gh_children` and `get_central_child` (geohash) were referenced nowhere — removed rather than tested, as PR #91 did for the unused traversal algorithms.

Suite: 187 → 200 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)