### PR TITLE
Drop the gdal Python binding requirement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,34 +21,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Micromamba (Python + GDAL)
-        uses: mamba-org/setup-micromamba@v3.1.0
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          environment-name: vector2dggs-ci
-          create-args: >-
-            python=3.11
-            gdal=3.13.1
+          python-version: "3.11"
 
       - name: Install Poetry
-        shell: bash -el {0}
         run: pip install poetry
 
       - name: Install dependencies
-        shell: bash -el {0}
         run: poetry install -E all --with dev
 
       - name: Lint (ruff)
-        shell: bash -el {0}
         run: poetry run ruff check .
 
       - name: Format check (black)
-        shell: bash -el {0}
         run: poetry run black --check .
 
       - name: Type check (mypy)
-        shell: bash -el {0}
         run: poetry run mypy vector2dggs/
 
       - name: Run tests
-        shell: bash -el {0}
         run: poetry run pytest -n auto tests/

--- a/README.md
+++ b/README.md
@@ -149,10 +149,9 @@ Compaction is supported with the `-co/--compact` argument. The result respects o
 In brief, to get started:
 
 - Install [Poetry](https://python-poetry.org/docs/basic-usage/)
-- Install [GDAL](https://gdal.org/)
-    - If you're on Windows, `pip install gdal` may be necessary before running the subsequent commands.
-    - On Linux, install GDAL 3.13.1+ according to your platform-specific instructions, including development headers, i.e. `libgdal-dev`. The Python `gdal` bindings must be matched by an equal-or-newer system `libgdal`.
 - Create and populate the virtual environment with `poetry install`. This will install necessary dependencies.
+
+No system GDAL is required: vector data is read via [pyogrio](https://pyogrio.readthedocs.io/), whose wheels bundle GDAL. If you need a GDAL driver that pyogrio's bundled build lacks, build pyogrio from source against your own GDAL.
 - Subsequently, activate the virtual environment with `eval "$(poetry env activate)"`.
 
 If you run `poetry install -E all --with dev` and activate the environment with `eval "$(poetry env activate)"`, the CLI tool will be aliased so you can simply use `vector2dggs` rather than `poetry run vector2dggs`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -807,20 +807,6 @@ test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "backports-zstd ; python_
 tqdm = ["tqdm"]
 
 [[package]]
-name = "gdal"
-version = "3.13.1"
-description = "GDAL: Geospatial Data Abstraction Library"
-optional = false
-python-versions = ">=3.8.0"
-groups = ["main"]
-files = [
-    {file = "gdal-3.13.1.tar.gz", hash = "sha256:94bb64d729ce73ceb75a314a15cba92696cdd854d99b6bf6b88a7b551227db74"},
-]
-
-[package.extras]
-numpy = ["numpy (>1.0.0)"]
-
-[[package]]
 name = "geoalchemy2"
 version = "0.20.0"
 description = "Using SQLAlchemy with Spatial Databases"
@@ -3433,4 +3419,4 @@ s2 = ["s2geometry"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "411f3926b9be5c0977fa867238b831972fec1127f69a28961effdaddf17e3421"
+content-hash = "ac15ba86ac18b12859ec4d7102b2a622e019bbe291f49007eefb4617b90d3650"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.11"
-gdal = ">=3.13.1"
 geopandas = "^1.1.2"
 pyogrio = "^0.13"
 dask-geopandas = "^0.5"


### PR DESCRIPTION
Fixes #161.

The `gdal = ">=3.13.1"` dependency dated to the project's first packaging commit (the fiona/system-GDAL era). Today nothing imports it, nothing in the dependency tree requires it, and it cannot affect behaviour: all vector IO goes through pyogrio, whose wheels bundle their own libgdal — the binding's presence adds no drivers to that.

It was also the project's single largest install cost: a source build requiring a matching system libgdal ≥3.13.1, the sole reason CI needed micromamba, and a paragraph of README workarounds. With it gone, `pip install vector2dggs[all]` is pure wheels, and CI is plain setup-python + poetry — **this PR's green test run on the simplified environment is the proof**, exercising the drivers the tool actually uses (GPKG, FlatGeobuf, PostGIS via testcontainers) without any system GDAL.

Users needing an exotic GDAL driver need a source-built pyogrio against their own GDAL regardless — the pin never served that case (noted in the README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)