### PR TITLE
Gate PyPI publishing on the test suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,30 +16,4 @@ jobs:
         uses : manaakiwhenua/manaakiwhenua-standards@v0.2.2
 
   test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Install Poetry
-        run: pip install poetry
-
-      - name: Install dependencies
-        run: poetry install -E all --with dev
-
-      - name: Lint (ruff)
-        run: poetry run ruff check .
-
-      - name: Format check (black)
-        run: poetry run black --check .
-
-      - name: Type check (mypy)
-        run: poetry run mypy vector2dggs/
-
-      - name: Run tests
-        run: poetry run pytest -n auto tests/
+    uses: ./.github/workflows/test.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,13 +8,17 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
   build:
+    needs: test
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install -E all --with dev
+
+      - name: Lint (ruff)
+        run: poetry run ruff check .
+
+      - name: Format check (black)
+        run: poetry run black --check .
+
+      - name: Type check (mypy)
+        run: poetry run mypy vector2dggs/
+
+      - name: Run tests
+        run: poetry run pytest -n auto tests/


### PR DESCRIPTION
Fixes #165.

`publish.yml` ran build → publish on a GitHub release with no tests: a tag on a broken or untested commit would upload to PyPI unchecked.

The test job (install `-E all`, ruff, black, mypy, pytest) now lives in a reusable workflow (`workflow_call`), used by both the push CI and the publish workflow — `build` (and therefore `publish`) depends on it, and the push and release checks cannot drift apart.

This PR's own CI run exercises the reusable workflow through the same call mechanism the release path uses; the release path itself is validated by the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)