### PR TITLE
Bump artifact actions off deprecated Node 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build distributions
         run: poetry build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -41,7 +41,7 @@ jobs:
       id-token: write  # required for OIDC trusted publisher
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Fixes #169.

The v0.18.0 release run warned that `upload-artifact@v4` and `download-artifact@v4` target deprecated Node 20. Bumped to the current majors (v7/v8); the usage here is the simple named-artifact case, unaffected by the intervening majors' breaking changes (hidden-file defaults, multi-artifact merging).

Release-triggered workflow, so the live validation happens at the next release — same caveat as the test gate it now sits behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)