### PR TITLE
Bound staged-file bundling by estimated cell output, not just row count

### DIFF
--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -1,8 +1,11 @@
+import math
 import tempfile
 from pathlib import Path
-from unittest import TestCase
+from unittest import TestCase, mock
 
+import geopandas as gpd
 import pandas as pd
+from shapely.geometry import box
 
 import vector2dggs.constants as const
 from vector2dggs import common
@@ -58,6 +61,73 @@ class TestWritePartitionGuards(TestCase):
             n = common.write_partition(df, None, Path(d), "p", "c", "snappy")
             self.assertEqual(n, 0)
             self.assertFalse(list(Path(d).iterdir()))
+
+
+class TestStagedFileChunks(TestCase):
+    """
+    _staged_file_chunks bounds staged files by estimated cell output, not
+    just row count (see issue #179: row-count-only sizing let a run of
+    similarly huge bisected features concentrate enough cells in one worker
+    task to exhaust memory).
+
+    A fake dggs with a 1 m^2 "cell" is registered so bbox area (in an
+    unset/planar CRS, i.e. no degree conversion) maps 1:1 to estimated cell
+    count, making test geometries exact rather than approximate.
+    """
+
+    def setUp(self):
+        self.area_patch = mock.patch.dict(
+            const.DGGS_CELL_AREA_M2_BY_RES, {"testdggs": lambda res: 1.0}
+        )
+        self.area_patch.start()
+        self.addCleanup(self.area_patch.stop)
+
+    def _chunks(self, sizes, max_rows, budget):
+        # sizes[i] is the desired estimated-cell count (== bbox area, m^2)
+        # of row i
+        geoms = [box(0, 0, math.sqrt(s), math.sqrt(s)) for s in sizes]
+        df = gpd.GeoDataFrame({"geometry": geoms})
+        with mock.patch.object(const, "MAX_CELLS_PER_STAGED_FILE", budget):
+            return list(common._staged_file_chunks(df, "testdggs", 1, max_rows))
+
+    def test_small_uniform_batch_stays_in_one_chunk(self):
+        chunks = self._chunks([1] * 1000, max_rows=2000, budget=500_000)
+        self.assertEqual(chunks, [(0, 1000)])
+
+    def test_row_count_backstop_still_applies_under_budget(self):
+        # cell budget is nowhere near reached; only the row-count cap should
+        # split this into two files
+        chunks = self._chunks([1] * 1000, max_rows=500, budget=500_000)
+        self.assertEqual(chunks, [(0, 500), (500, 1000)])
+
+    def test_large_rows_split_by_cell_budget_despite_low_row_count(self):
+        # three rows of 300 "cells" each; budget of 500 means no two can
+        # share a file, even though max_rows would allow it
+        chunks = self._chunks([300, 300, 300], max_rows=100, budget=500)
+        self.assertEqual(chunks, [(0, 1), (1, 2), (2, 3)])
+
+    def test_single_oversized_row_still_gets_its_own_chunk(self):
+        # a single row far exceeding the budget must not be dropped or loop
+        # forever -- it gets a (degenerate) chunk of its own
+        chunks = self._chunks([10_000], max_rows=100, budget=500)
+        self.assertEqual(chunks, [(0, 1)])
+
+    def test_empty_batch_yields_no_chunks(self):
+        df = gpd.GeoDataFrame({"geometry": []})
+        chunks = list(common._staged_file_chunks(df, "testdggs", 1, 100))
+        self.assertEqual(chunks, [])
+
+    def test_geographic_crs_converts_degrees_before_estimating(self):
+        # ~1 degree square at the equator is ~(111km)^2, not ~1 m^2. With
+        # the conversion, two such rows blow a budget of 1000 "cells" and
+        # must split; without it, raw degree^2 area (~1 each) would stay
+        # well under budget and wrongly stay in one file.
+        df = gpd.GeoDataFrame(
+            {"geometry": [box(0, 0, 1, 1), box(2, 0, 3, 1)]}, crs="EPSG:4326"
+        )
+        with mock.patch.object(const, "MAX_CELLS_PER_STAGED_FILE", 1000):
+            chunks = list(common._staged_file_chunks(df, "testdggs", 1, 100))
+        self.assertEqual(chunks, [(0, 1), (1, 2)])
 
 
 class TestCommitOutput(TestCase):

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -42,6 +42,8 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestGetParentRes as TestGetParentRes
 with contextlib.suppress(ImportError):
+    from .classes.common_units import TestStagedFileChunks as TestStagedFileChunks
+with contextlib.suppress(ImportError):
     from .classes.common_units import (
         TestWritePartitionGuards as TestWritePartitionGuards,
     )

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -4,6 +4,7 @@ import math
 import multiprocessing
 import shutil
 import tempfile
+from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from pathlib import Path, PurePath
 from types import ModuleType
@@ -851,6 +852,44 @@ def _clean_geometries(df: gpd.GeoDataFrame, indexer: VectorIndexer) -> gpd.GeoDa
     return df
 
 
+def _staged_file_chunks(
+    batch: gpd.GeoDataFrame, dggs: str, resolution: int, max_rows: int
+) -> Iterator[tuple[int, int]]:
+    """
+    Yield (start, end) row-position ranges bundling batch into successive
+    staged files (and therefore _polyfill() worker tasks), so that no one
+    file's estimated total cell output much exceeds
+    const.MAX_CELLS_PER_STAGED_FILE, in addition to the max_rows backstop.
+
+    Per-row cell counts are estimated from bounding-box area -- the same
+    approximation bisection itself uses to size cut pieces -- converting
+    degrees to an approximate metre scale when the CRS is geographic. This
+    is only a heuristic bound: an exact count would mean running polyfill
+    itself, which is the expensive step this is sizing work for.
+    """
+    bounds = batch.geometry.bounds
+    bbox_area = (bounds["maxx"] - bounds["minx"]) * (bounds["maxy"] - bounds["miny"])
+    if batch.crs is not None and batch.crs.is_geographic:
+        axis = batch.crs.axis_info[0]
+        metres_per_unit = axis.unit_conversion_factor * const.EARTH_MEAN_RADIUS_M
+        bbox_area = bbox_area * metres_per_unit**2
+    cell_area_m2 = const.DGGS_CELL_AREA_M2_BY_RES[dggs](resolution)
+    est_cells = np.maximum(1.0, bbox_area.to_numpy() / cell_area_m2)
+
+    start = 0
+    running = 0.0
+    for i, cells in enumerate(est_cells):
+        if i > start and (
+            running + cells > const.MAX_CELLS_PER_STAGED_FILE or i - start >= max_rows
+        ):
+            yield start, i
+            start = i
+            running = 0.0
+        running += cells
+    if start < len(est_cells):
+        yield start, len(est_cells)
+
+
 def _mp_context() -> multiprocessing.context.BaseContext:
     """Never fork: the parent is multi-threaded by the time the pool starts."""
     methods = multiprocessing.get_all_start_methods()
@@ -988,8 +1027,10 @@ def _index(
         )
         return
 
-    # a handful of staged files per worker balances the pool; row count
-    # per file is clamped so worker memory stays bounded
+    # a handful of staged files per worker balances the pool; row count is
+    # a backstop cap, but _staged_file_chunks additionally bounds files by
+    # estimated cell output, since row count alone isn't a safe proxy for
+    # worker memory (see const.MAX_CELLS_PER_STAGED_FILE)
     rows_per_file = min(
         const.STAGED_FILE_MAX_ROWS,
         max(
@@ -1025,8 +1066,10 @@ def _index(
             blade_segment = _blade_segment(indexer, dggs, resolution, cut_crs)
             batch = _run_bisection(batch, cut_threshold, processes, blade_segment)
             batch = _clean_geometries(batch, indexer)
-            for start in range(0, len(batch), rows_per_file):
-                batch.iloc[start : start + rows_per_file].to_parquet(
+            for start, end in _staged_file_chunks(
+                batch, dggs, resolution, rows_per_file
+            ):
+                batch.iloc[start:end].to_parquet(
                     PurePath(tmpdir, f"part-{part:06}.parquet")
                 )
                 part += 1

--- a/vector2dggs/constants.py
+++ b/vector2dggs/constants.py
@@ -184,6 +184,14 @@ INGEST_MAX_BATCH_ROWS = 1_000_000
 STAGED_FILES_PER_WORKER = 5
 STAGED_FILE_MAX_ROWS = 5000
 
+# Backstop on estimated total cell output (from bounding-box area) bundled
+# into one staged file, hence one _polyfill() worker task. Row count alone
+# is not a safe proxy: bisection targets ~DEFAULT_CUT_CELLS_PER_PIECE cells
+# per piece, but a run of similarly large/complex features stored
+# contiguously in the source (e.g. one land-cover class) can otherwise
+# concentrate thousands of near-maximum-size pieces in a single task.
+MAX_CELLS_PER_STAGED_FILE = 500_000
+
 
 # Default bisection granularity: pieces sized to roughly this many cells of
 # the target resolution. Benchmarked on national-scale coastline data: flat


### PR DESCRIPTION
## Summary

`_index()` sized staged worker files (`rows_per_file`) purely from the pre-bisection feature count, with no awareness of how many DGGS cells those rows would actually explode into. Bisection already targets ~`DEFAULT_CUT_CELLS_PER_PIECE` cells per piece, but nothing stopped a run of similarly huge pieces (e.g. one land-cover class stored contiguously in the source) from landing in the same staged file -- and therefore the same `_polyfill()` worker task -- concentrating enough cells to exhaust memory at fine resolutions.

Adds `_staged_file_chunks()`, which greedily bundles rows into a staged file using a running estimated-cell-count budget (from bounding-box area, the same heuristic bisection itself uses), falling back to the existing row-count cap as a backstop. `const.MAX_CELLS_PER_STAGED_FILE` is the new budget constant.

Confirmed against a real 542,789-feature national land-cover dataset that previously froze the machine solid at a fine resolution (full numbers in the linked issue); manually forcing smaller pieces (`--cut_threshold`) and fewer concurrent workers (`--threads`) confirmed the diagnosis before this fix, so the fix targets the actual root cause rather than a guess.

Closes #179

## Test plan
- [x] New `TestStagedFileChunks` unit tests: uniform small batches stay bundled, the row-count backstop still applies under budget, large rows split by cell budget despite low row count, a single oversized row still gets a (degenerate) chunk of its own rather than looping or being dropped, empty batches yield nothing, geographic-CRS degree-to-metre conversion is exercised (confirmed these fail against the old naive row-count-only chunking before writing the fix)
- [x] `ruff check .` clean
- [x] `black --check .` clean
- [x] `mypy vector2dggs/` clean
- [x] Full test suite: 208 passed
- [x] CI green on the branch before opening this PR