### PR TITLE
Fix OOM/machine freeze at fine resolutions, especially with --keep_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ Options:
                                   bisection entirely (effectively ignoring
                                   --cut_crs).
   -t, --threads INTEGER RANGE     Amount of threads used for operation
-                                  [default: (CPU count - 1); x>=1]
+                                  [default: (CPU count - 1, capped by available
+                                  memory); x>=1]
   -cp, --compression TEXT         Compression method to use for the output
                                   Parquet files. Options include 'snappy',
                                   'gzip', 'brotli', 'lz4', 'zstd', etc. Use

--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -1,6 +1,6 @@
 import tempfile
 from pathlib import Path
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pandas as pd
 
@@ -21,6 +21,77 @@ class TestGetParentRes(TestCase):
     def test_unknown_dggs_raises(self):
         with self.assertRaises(RuntimeError):
             common.get_parent_res("not_a_dggs", None, 9)
+
+
+class TestAvailableMemoryMb(TestCase):
+    def test_parses_mem_available_line(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "meminfo"
+            path.write_text(
+                "MemTotal:       16384000 kB\nMemAvailable:    8192000 kB\n"
+            )
+            self.assertEqual(const._available_memory_mb(str(path)), 8000)
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(const._available_memory_mb("/no/such/file"))
+
+    def test_missing_mem_available_line_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "meminfo"
+            path.write_text("MemTotal:       16384000 kB\n")
+            self.assertIsNone(const._available_memory_mb(str(path)))
+
+
+class TestDefaultThreads(TestCase):
+    """
+    See issue #183: --threads defaulted to CPU count alone, with no regard
+    for available memory, which could overcommit a memory-thin machine
+    regardless of how lean each worker task was.
+    """
+
+    def test_falls_back_to_cpu_count_when_memory_unknown(self):
+        with (
+            mock.patch.object(const.multiprocessing, "cpu_count", return_value=9),
+            mock.patch.object(const, "_available_memory_mb", return_value=None),
+        ):
+            self.assertEqual(const.default_threads(), 8)
+
+    def test_caps_by_available_memory(self):
+        with (
+            mock.patch.object(const.multiprocessing, "cpu_count", return_value=32),
+            mock.patch.object(const, "_available_memory_mb", return_value=2048),
+            mock.patch.object(const, "RESERVED_MB_PER_WORKER", 512),
+            mock.patch.object(const, "AVAILABLE_MEMORY_BUDGET_FRACTION", 1.0),
+        ):
+            self.assertEqual(const.default_threads(), 4)
+
+    def test_budget_fraction_reduces_effective_cap(self):
+        # Only a fraction of available memory is budgeted, leaving headroom
+        # for other processes on the machine and for this one-shot-at-
+        # startup reading to hold for a run lasting several minutes.
+        with (
+            mock.patch.object(const.multiprocessing, "cpu_count", return_value=32),
+            mock.patch.object(const, "_available_memory_mb", return_value=2048),
+            mock.patch.object(const, "RESERVED_MB_PER_WORKER", 512),
+            mock.patch.object(const, "AVAILABLE_MEMORY_BUDGET_FRACTION", 0.5),
+        ):
+            self.assertEqual(const.default_threads(), 2)
+
+    def test_never_goes_below_one(self):
+        with (
+            mock.patch.object(const.multiprocessing, "cpu_count", return_value=32),
+            mock.patch.object(const, "_available_memory_mb", return_value=10),
+            mock.patch.object(const, "RESERVED_MB_PER_WORKER", 512),
+        ):
+            self.assertEqual(const.default_threads(), 1)
+
+    def test_memory_cap_never_exceeds_cpu_based_default(self):
+        with (
+            mock.patch.object(const.multiprocessing, "cpu_count", return_value=4),
+            mock.patch.object(const, "_available_memory_mb", return_value=1_000_000),
+            mock.patch.object(const, "RESERVED_MB_PER_WORKER", 512),
+        ):
+            self.assertEqual(const.default_threads(), 3)
 
 
 class TestDropCondition(TestCase):

--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -2,7 +2,9 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase
 
+import geopandas as gpd
 import pandas as pd
+from shapely.geometry import Point
 
 import vector2dggs.constants as const
 from vector2dggs import common
@@ -58,6 +60,48 @@ class TestWritePartitionGuards(TestCase):
             n = common.write_partition(df, None, Path(d), "p", "c", "snappy")
             self.assertEqual(n, 0)
             self.assertFalse(list(Path(d).iterdir()))
+
+
+class TestDictionaryEncodeAttributes(TestCase):
+    """
+    _dictionary_encode_attributes casts string attribute columns to category
+    dtype (see issue #181: --keep_attributes duplicates the full attribute
+    payload onto every generated cell; dictionary encoding turns repeated
+    values into small integer codes referencing one shared dictionary,
+    rather than independent string copies per cell).
+    """
+
+    def test_object_columns_become_categorical(self):
+        gdf = gpd.GeoDataFrame(
+            {
+                "geometry": [Point(0, 0), Point(1, 1)],
+                "class": ["forest", "wetland"],
+                "count": [1, 2],
+            }
+        )
+        result = common._dictionary_encode_attributes(gdf)
+        self.assertEqual(result["class"].dtype, "category")
+        self.assertEqual(list(result["class"]), ["forest", "wetland"])
+
+    def test_numeric_and_geometry_columns_untouched(self):
+        gdf = gpd.GeoDataFrame({"geometry": [Point(0, 0)], "count": [1]})
+        result = common._dictionary_encode_attributes(gdf)
+        self.assertEqual(result["count"].dtype, gdf["count"].dtype)
+        self.assertEqual(result.geometry.name, "geometry")
+
+    def test_no_string_columns_is_a_no_op(self):
+        gdf = gpd.GeoDataFrame({"geometry": [Point(0, 0)], "count": [1]})
+        result = common._dictionary_encode_attributes(gdf)
+        pd.testing.assert_frame_equal(result, gdf)
+
+    def test_prepare_dataframe_encodes_only_when_keeping_attributes(self):
+        gdf = gpd.GeoDataFrame({"geometry": [Point(0, 0)], "class": ["forest"]})
+
+        kept = common._prepare_dataframe(gdf.copy(), None, keep_attributes=True)
+        self.assertEqual(kept["class"].dtype, "category")
+
+        dropped = common._prepare_dataframe(gdf.copy(), None, keep_attributes=False)
+        self.assertNotIn("class", dropped.columns)
 
 
 class TestCommitOutput(TestCase):

--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -1,8 +1,11 @@
+import math
 import tempfile
 from pathlib import Path
-from unittest import TestCase
+from unittest import TestCase, mock
 
+import geopandas as gpd
 import pandas as pd
+from shapely.geometry import box
 
 import vector2dggs.constants as const
 from vector2dggs import common
@@ -58,6 +61,73 @@ class TestWritePartitionGuards(TestCase):
             n = common.write_partition(df, None, Path(d), "p", "c", "snappy")
             self.assertEqual(n, 0)
             self.assertFalse(list(Path(d).iterdir()))
+
+
+class TestStagedFileChunks(TestCase):
+    """
+    _staged_file_chunks bounds staged files by estimated cell output, not
+    just row count (see issue #179: row-count-only sizing let a run of
+    similarly huge bisected features concentrate enough cells in one worker
+    task to exhaust memory).
+
+    A fake dggs with a 1 m^2 "cell" is registered so bbox area (in an
+    unset/planar CRS, i.e. no degree conversion) maps 1:1 to estimated cell
+    count, making test geometries exact rather than approximate.
+    """
+
+    def setUp(self):
+        self.area_patch = mock.patch.dict(
+            const.DGGS_CELL_AREA_M2_BY_RES, {"testdggs": lambda res: 1.0}
+        )
+        self.area_patch.start()
+        self.addCleanup(self.area_patch.stop)
+
+    def _chunks(self, sizes, max_rows, budget):
+        # sizes[i] is the desired estimated-cell count (== bbox area, m^2)
+        # of row i
+        geoms = [box(0, 0, math.sqrt(s), math.sqrt(s)) for s in sizes]
+        df = gpd.GeoDataFrame({"geometry": geoms})
+        with mock.patch.object(const, "MAX_CELLS_PER_STAGED_FILE", budget):
+            return list(common._staged_file_chunks(df, "testdggs", 1, max_rows))
+
+    def test_small_uniform_batch_stays_in_one_chunk(self):
+        chunks = self._chunks([1] * 1000, max_rows=2000, budget=500_000)
+        self.assertEqual(chunks, [(0, 1000)])
+
+    def test_row_count_backstop_still_applies_under_budget(self):
+        # cell budget is nowhere near reached; only the row-count cap should
+        # split this into two files
+        chunks = self._chunks([1] * 1000, max_rows=500, budget=500_000)
+        self.assertEqual(chunks, [(0, 500), (500, 1000)])
+
+    def test_large_rows_split_by_cell_budget_despite_low_row_count(self):
+        # three rows of 300 "cells" each; budget of 500 means no two can
+        # share a file, even though max_rows would allow it
+        chunks = self._chunks([300, 300, 300], max_rows=100, budget=500)
+        self.assertEqual(chunks, [(0, 1), (1, 2), (2, 3)])
+
+    def test_single_oversized_row_still_gets_its_own_chunk(self):
+        # a single row far exceeding the budget must not be dropped or loop
+        # forever -- it gets a (degenerate) chunk of its own
+        chunks = self._chunks([10_000], max_rows=100, budget=500)
+        self.assertEqual(chunks, [(0, 1)])
+
+    def test_empty_batch_yields_no_chunks(self):
+        df = gpd.GeoDataFrame({"geometry": []})
+        chunks = list(common._staged_file_chunks(df, "testdggs", 1, 100))
+        self.assertEqual(chunks, [])
+
+    def test_geographic_crs_converts_degrees_before_estimating(self):
+        # ~1 degree square at the equator is ~(111km)^2, not ~1 m^2. With
+        # the conversion, two such rows blow a budget of 1000 "cells" and
+        # must split; without it, raw degree^2 area (~1 each) would stay
+        # well under budget and wrongly stay in one file.
+        df = gpd.GeoDataFrame(
+            {"geometry": [box(0, 0, 1, 1), box(2, 0, 3, 1)]}, crs="EPSG:4326"
+        )
+        with mock.patch.object(const, "MAX_CELLS_PER_STAGED_FILE", 1000):
+            chunks = list(common._staged_file_chunks(df, "testdggs", 1, 100))
+        self.assertEqual(chunks, [(0, 1), (1, 2)])
 
 
 class TestCommitOutput(TestCase):

--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -59,6 +59,16 @@ class TestWritePartitionGuards(TestCase):
             self.assertEqual(n, 0)
             self.assertFalse(list(Path(d).iterdir()))
 
+    def test_mutates_input_in_place(self):
+        # See issue #182: write_partition no longer defensively copies its
+        # input (the caller, _polyfill(), computes what it needs from the
+        # original before calling this). Locking in the "may mutate"
+        # contract here so a defensive copy doesn't silently creep back in.
+        df = pd.DataFrame({"c": ["a", "b"], "p": [1, 2]})
+        with tempfile.TemporaryDirectory() as d:
+            common.write_partition(df, None, Path(d), "p", "c", "snappy")
+        self.assertEqual(df["p"].dtype, "string")
+
 
 class TestCommitOutput(TestCase):
     def test_refuses_directory_created_mid_run_without_overwrite(self):

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -36,7 +36,11 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.compaction import TestS2CompactionBounds as TestS2CompactionBounds
 with contextlib.suppress(ImportError):
+    from .classes.common_units import TestAvailableMemoryMb as TestAvailableMemoryMb
+with contextlib.suppress(ImportError):
     from .classes.common_units import TestCommitOutput as TestCommitOutput
+with contextlib.suppress(ImportError):
+    from .classes.common_units import TestDefaultThreads as TestDefaultThreads
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestDropCondition as TestDropCondition
 with contextlib.suppress(ImportError):

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -42,6 +42,8 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestGetParentRes as TestGetParentRes
 with contextlib.suppress(ImportError):
+    from .classes.common_units import TestStagedFileChunks as TestStagedFileChunks
+with contextlib.suppress(ImportError):
     from .classes.common_units import (
         TestWritePartitionGuards as TestWritePartitionGuards,
     )

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -38,6 +38,10 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestCommitOutput as TestCommitOutput
 with contextlib.suppress(ImportError):
+    from .classes.common_units import (
+        TestDictionaryEncodeAttributes as TestDictionaryEncodeAttributes,
+    )
+with contextlib.suppress(ImportError):
     from .classes.common_units import TestDropCondition as TestDropCondition
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestGetParentRes as TestGetParentRes

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -78,7 +78,7 @@ def make_dggs_command(
         "--threads",
         required=False,
         default=const.DEFAULTS["t"],
-        show_default="CPU count - 1",
+        show_default="CPU count - 1, capped by available memory",
         type=click.IntRange(min=1),
         help="Amount of threads used for operation",
         nargs=1,

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -215,6 +215,10 @@ def write_partition(
     """
     Hive-partitioned parquet write of one dataframe; GeoParquet when
     geo_serialisation_method (cell -> shapely geometry) is given.
+
+    May mutate partition_df in place (columns added/retyped, rows dropped,
+    row order changed) -- callers that need the original afterward must
+    copy it themselves first.
     """
     if partition_df.empty:
         return 0
@@ -241,19 +245,18 @@ def write_partition(
     if not bool(valid_cell_mask.any()):
         return 0
     if not bool(valid_cell_mask.all()):
-        partition_df = partition_df.loc[valid_cell_mask].copy()
+        partition_df = partition_df.loc[valid_cell_mask]
         cell_ids = cell_ids.loc[valid_cell_mask]
 
-    pdf = partition_df.copy()
-    pdf[partition_col] = pdf[partition_col].astype("string")
+    partition_df[partition_col] = partition_df[partition_col].astype("string")
     if geo_serialisation_method is not None:
-        pdf["geometry"] = shapely.to_wkb(
+        partition_df["geometry"] = shapely.to_wkb(
             cell_ids.map(geo_serialisation_method), hex=False
         )
     # sorted by partition value: one file per parent cell, no writer churn
-    pdf = pdf.sort_values(partition_col, kind="stable")
+    partition_df.sort_values(partition_col, kind="stable", inplace=True)
 
-    table = pa.Table.from_pandas(pdf, preserve_index=True)
+    table = pa.Table.from_pandas(partition_df, preserve_index=True)
     if geo_serialisation_method is not None:
         table = _with_geoparquet_metadata(table)
 
@@ -273,10 +276,10 @@ def write_partition(
         max_open_files=const.MAX_OPEN_FILES_PER_TASK,
         # pyarrow's default max_partitions (1024) is a safety valve; this
         # batch's true partition count is known, so pass it exactly
-        max_partitions=max(1, int(pdf[partition_col].nunique())),
+        max_partitions=max(1, int(partition_df[partition_col].nunique())),
     )
 
-    return int(len(pdf.index) > 0)
+    return int(len(partition_df.index) > 0)
 
 
 def _with_geoparquet_metadata(table: pa.Table) -> pa.Table:
@@ -508,6 +511,9 @@ def _polyfill(
     # Secondary (parent) index, used for hive partitioning
     df = indexer.secondary_index(df, parent_res)
 
+    # Computed before write_partition, which may mutate/filter df in place
+    indexed_ids = df[id_col].unique()
+
     # With compaction, geometry is serialised after compacting (merge step)
     geom_fn = None if compact else _geom_fn(indexer, geo)
     write_partition(
@@ -518,7 +524,7 @@ def _polyfill(
         f"{indexer.dggs}_{resolution:02}",
         compression,
     )
-    return df[id_col].unique()
+    return indexed_ids
 
 
 def _polyfill_star(args) -> np.ndarray:

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -686,6 +686,32 @@ def _read_batches(
         rows = _next_batch_rows(batch)
 
 
+def _dictionary_encode_attributes(df: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """
+    Cast string attribute columns (object-dtype or pandas' newer StringDtype)
+    to pandas' category dtype.
+
+    Attribute values are attached once per input feature here, then
+    duplicated onto every cell that feature explodes into by polyfill() --
+    so a column's distinct-value count is bounded by feature count, while
+    its row count downstream is bounded by (much larger) cell count.
+    Dictionary encoding turns that duplication into small integer codes
+    referencing one shared dictionary instead of independent string copies.
+    This is preserved through the rest of the pipeline (explode, boolean
+    subsetting, Arrow conversion) as long as frames built from genuinely
+    different sources are combined via pyarrow rather than pandas -- pandas'
+    own concat silently drops dictionary encoding when inputs don't share
+    the same categories object.
+    """
+    geom_col = df.geometry.name
+    string_cols = [
+        c for c in df.columns if c != geom_col and pd.api.types.is_string_dtype(df[c])
+    ]
+    if string_cols:
+        df = df.astype(dict.fromkeys(string_cols, "category"))
+    return df
+
+
 def _prepare_dataframe(
     df: gpd.GeoDataFrame,
     id_field: str | None,
@@ -699,6 +725,8 @@ def _prepare_dataframe(
         df.index = pd.RangeIndex(fid_offset, fid_offset + len(df), name="fid")
     if not keep_attributes:
         df = df.loc[:, ["geometry"]]
+    else:
+        df = _dictionary_encode_attributes(df)
     return df
 
 

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -4,6 +4,7 @@ import math
 import multiprocessing
 import shutil
 import tempfile
+from collections.abc import Iterator
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from pathlib import Path, PurePath
 from types import ModuleType
@@ -851,6 +852,44 @@ def _clean_geometries(df: gpd.GeoDataFrame, indexer: VectorIndexer) -> gpd.GeoDa
     return df
 
 
+def _staged_file_chunks(
+    batch: gpd.GeoDataFrame, dggs: str, resolution: int, max_rows: int
+) -> Iterator[tuple[int, int]]:
+    """
+    Yield (start, end) row-position ranges bundling batch into successive
+    staged files (and therefore _polyfill() worker tasks), so that no one
+    file's estimated total cell output much exceeds
+    const.MAX_CELLS_PER_STAGED_FILE, in addition to the max_rows backstop.
+
+    Per-row cell counts are estimated from bounding-box area -- the same
+    approximation bisection itself uses to size cut pieces -- converting
+    degrees to an approximate metre scale when the CRS is geographic. This
+    is only a heuristic bound: an exact count would mean running polyfill
+    itself, which is the expensive step this is sizing work for.
+    """
+    bounds = batch.geometry.bounds
+    bbox_area = (bounds["maxx"] - bounds["minx"]) * (bounds["maxy"] - bounds["miny"])
+    if batch.crs is not None and batch.crs.is_geographic:
+        axis = batch.crs.axis_info[0]
+        metres_per_unit = axis.unit_conversion_factor * const.EARTH_MEAN_RADIUS_M
+        bbox_area = bbox_area * metres_per_unit**2
+    cell_area_m2 = const.DGGS_CELL_AREA_M2_BY_RES[dggs](resolution)
+    est_cells = np.maximum(1.0, bbox_area.to_numpy() / cell_area_m2)
+
+    start = 0
+    running = 0.0
+    for i, cells in enumerate(est_cells):
+        if i > start and (
+            running + cells > const.MAX_CELLS_PER_STAGED_FILE or i - start >= max_rows
+        ):
+            yield start, i
+            start = i
+            running = 0.0
+        running += cells
+    if start < len(est_cells):
+        yield start, len(est_cells)
+
+
 def _mp_context() -> multiprocessing.context.BaseContext:
     """Never fork: the parent is multi-threaded by the time the pool starts."""
     methods = multiprocessing.get_all_start_methods()
@@ -988,8 +1027,10 @@ def _index(
         )
         return
 
-    # a handful of staged files per worker balances the pool; row count
-    # per file is clamped so worker memory stays bounded
+    # a handful of staged files per worker balances the pool; row count is
+    # a backstop cap, but _staged_file_chunks additionally bounds files by
+    # estimated cell output, since row count alone isn't a safe proxy for
+    # worker memory (see const.MAX_CELLS_PER_STAGED_FILE)
     rows_per_file = min(
         const.STAGED_FILE_MAX_ROWS,
         max(
@@ -1025,8 +1066,10 @@ def _index(
             blade_segment = _blade_segment(indexer, dggs, resolution, cut_crs)
             batch = _run_bisection(batch, cut_threshold, processes, blade_segment)
             batch = _clean_geometries(batch, indexer)
-            for start in range(0, len(batch), rows_per_file):
-                batch.iloc[start : start + rows_per_file].to_parquet(
+            for start, end in _staged_file_chunks(
+                batch, dggs, resolution, rows_per_file
+            ):
+                batch.iloc[start:end].to_parquet(
                     PurePath(tmpdir, f"part-{part:06}.parquet")
                 )
                 part += 1

--- a/vector2dggs/constants.py
+++ b/vector2dggs/constants.py
@@ -184,6 +184,14 @@ INGEST_MAX_BATCH_ROWS = 1_000_000
 STAGED_FILES_PER_WORKER = 5
 STAGED_FILE_MAX_ROWS = 5000
 
+# Backstop on estimated total cell output (from bounding-box area) bundled
+# into one staged file, hence one _polyfill() worker task. Row count alone
+# is not a safe proxy: bisection targets ~DEFAULT_CUT_CELLS_PER_PIECE cells
+# per piece, but a run of similarly large/complex features stored
+# contiguously in the source (e.g. one land-cover class) can otherwise
+# concentrate thousands of near-maximum-size pieces in a single task.
+MAX_CELLS_PER_STAGED_FILE = 500_000
+
 
 # Default bisection granularity: pieces sized to roughly this many cells of
 # the target resolution. Benchmarked on national-scale coastline data: flat

--- a/vector2dggs/constants.py
+++ b/vector2dggs/constants.py
@@ -197,12 +197,62 @@ def DEFAULT_AREA_THRESHOLD_M2(dggs, resolution):
     return DEFAULT_CUT_CELLS_PER_PIECE * DGGS_CELL_AREA_M2_BY_RES[dggs](resolution)
 
 
+# Conservative per-worker memory reservation for the default --threads cap.
+# Deliberately not tuned to the lightest case (bare cell indexing uses far
+# less) nor tailored per dataset/resolution/--keep_attributes -- it's a
+# single default meant to keep concurrency from overcommitting a
+# memory-thin machine without needlessly throttling a well-provisioned one.
+# Set well above the measured per-worker peak RSS (~122MB import baseline +
+# up to ~370MB task data, so ~490MB, on a fine-resolution --keep_attributes
+# run): available memory is sampled once at startup and this default holds
+# for the whole run, so it needs headroom for other processes on the same
+# machine growing in the meantime, not just this run's own peak.
+RESERVED_MB_PER_WORKER = 768
+
+# Only this fraction of currently-available memory is treated as usable for
+# the --threads cap above, for the same reason: a live reading taken once
+# at startup, held for a run that can last many minutes, on a machine other
+# processes also use.
+AVAILABLE_MEMORY_BUDGET_FRACTION = 0.7
+
+
+def _available_memory_mb(meminfo_path: str = "/proc/meminfo") -> int | None:
+    """
+    Currently available system memory in MB, from /proc/meminfo's
+    MemAvailable (already accounts for reclaimable cache, unlike raw
+    "free"). Returns None if it can't be determined (non-Linux, or a
+    missing/malformed file), so callers can fall back to a CPU-only default.
+    """
+    try:
+        with open(meminfo_path) as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) // 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def default_threads() -> int:
+    """
+    CPU count - 1, further capped by a budget of available memory /
+    RESERVED_MB_PER_WORKER when available memory can be determined, so a
+    memory-thin machine doesn't overcommit concurrency by CPU count alone.
+    """
+    cpu_based = max(1, multiprocessing.cpu_count() - 1)
+    available_mb = _available_memory_mb()
+    if available_mb is None:
+        return cpu_based
+    budget_mb = available_mb * AVAILABLE_MEMORY_BUDGET_FRACTION
+    return max(1, min(cpu_based, int(budget_mb // RESERVED_MB_PER_WORKER)))
+
+
 DEFAULTS = {
     "id": None,
     "k": False,
     "crs": None,
     "c": None,
-    "t": max(1, multiprocessing.cpu_count() - 1),
+    "t": default_threads(),
     "cp": "snappy",
     "lyr": None,
     "g": "geom",


### PR DESCRIPTION
## Summary

A real 542,789-feature national land-cover dataset (EPSG:2193), indexed to S2 resolution 17, froze the machine solid (hard reset required) both with and without `--keep_attributes`. This turned out to be four separate, compounding mechanisms -- each fixed individually here, but only the combination actually resolves the reported crash, which is why this is one PR rather than four.

### #179 -- staged-file sizing ignored expected cell output

`_index()` sized staged worker files (and therefore `_polyfill()` worker tasks) purely from the pre-bisection feature count, with no awareness of how many cells those rows would explode into. A run of similarly huge bisected features stored contiguously in the source (e.g. one land-cover class) could concentrate thousands of near-maximum-size pieces in a single task. `_staged_file_chunks()` now bounds staged files by an estimated cell-output budget (from bounding-box area, the same heuristic bisection itself uses), not just row count.

This alone fixed the crash for the non-`--keep_attributes` case (confirmed against the real dataset before continuing).

### #181 -- `--keep_attributes` duplicates the full attribute payload onto every cell

`polyfill()` explodes each input row into one row per generated cell, duplicating every attribute value onto each one. Since attribute values are set once per input feature, a column's distinct-value count is bounded by feature count regardless of the much larger cell count downstream -- exactly the situation dictionary encoding is for. String attribute columns are now cast to pandas' `category` dtype in `_prepare_dataframe`, verified empirically (not assumed) to survive `.explode()`, boolean-indexed subsetting + `pd.concat`, `pyarrow.concat_tables` across genuinely different dictionaries, and `Table.to_pandas()` for compaction.

### #182 -- `write_partition()` stacked avoidable copies

A defensive `partition_df.copy()` (plus a second copy on the valid-cell-mask path, plus a non-in-place `sort_values`) existed only so the caller's dataframe survived the call untouched -- but the caller, `_polyfill()`, only needed that because it called `df[id_col].unique()` *after* `write_partition(df, ...)`. Reordering that computation removes the need entirely; `write_partition` now mutates the frame it's given.

### #183 -- default `--threads` ignored available memory

Diagnostics (adding temporary per-task RSS logging) showed #181+#182 got per-worker peak memory down to a modest ~300-370MB -- individually reasonable. But `--threads` defaults to `NUM_CPUS - 1` with zero regard for available memory, and on a thin memory-per-core machine (20 cores, 14GiB here), 19 such workers plus normal system overhead added up to almost exactly the machine's RAM. `default_threads()` now also caps by `available_memory * AVAILABLE_MEMORY_BUDGET_FRACTION / RESERVED_MB_PER_WORKER`, reading available memory from `/proc/meminfo` (falls back to the current CPU-only default elsewhere or if undeterminable). This took two calibration passes: the first (fraction=1.0, no margin) still tipped the machine over at ~24% through indexing, since available memory is sampled once at startup but has to hold for a run lasting many minutes on a machine other processes also use.

## Validation

Each fix has its own unit tests (19 new, listed below). Beyond that, this was validated live against the actual reproduction case on the same physical machine that froze, using a memory-watchdog wrapper script (kills the process group before a repeat freeze if available memory drops dangerously) rather than trusting synthetic tests alone:

- Confirmed the crash reproduces on `main` (before any of these fixes)
- Confirmed #179 alone fixes the non-`--keep_attributes` case
- Confirmed #179+#181+#182 alone still crash with `--keep_attributes` (~8% through indexing)
- Added temporary diagnostic instrumentation to `_polyfill()` to find the actual per-worker peak memory, rather than continuing to guess
- Confirmed all four together complete the exact original command (`-r 17 --keep_attributes --compact`, no manual `-c`/`-t` overrides) in ~16 minutes, with output verified for correctness (full attribute columns retained, correct S2 cell indexing, compaction applied)

## Test plan
- [x] 19 new unit tests across `_staged_file_chunks`, `_dictionary_encode_attributes`, `write_partition`'s mutate-in-place contract, `_available_memory_mb`, `default_threads`
- [x] `ruff check .` clean
- [x] `black --check .` clean
- [x] `mypy vector2dggs/` clean
- [x] Full test suite: 221 passed
- [x] CI green on the branch before opening this PR
- [x] Live end-to-end validation against the real reproduction case (see above)

Closes #179, #181, #182, #183