### PR TITLE
Allow selecting specific attributes to keep via -ka/--keep_attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Options:
                                   create an output that only includes H3 cell ID
                                   and the ID given by the -id field (or the
                                   default index ID).
+  -ka, --keep_attribute TEXT      Retain only this attribute in output; repeat
+                                  for multiple. Takes precedence over
+                                  -k/--keep_attributes.
   -crs, --cut_crs INTEGER         Set the coordinate reference system (CRS) used
                                   for cutting large geometries (see
                                   `--cut_threshold`). Defaults to the same CRS

--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -10,6 +10,8 @@ from shapely.geometry import Point, box
 import vector2dggs.constants as const
 from vector2dggs import common
 
+from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME
+
 
 class TestGetParentRes(TestCase):
     def test_explicit_parent_passes_through(self):
@@ -95,6 +97,74 @@ class TestDefaultThreads(TestCase):
             mock.patch.object(const, "RESERVED_MB_PER_WORKER", 512),
         ):
             self.assertEqual(const.default_threads(), 3)
+
+
+class TestCheckRequestedAttributes(TestCase):
+    def test_no_attributes_requested_is_a_noop(self):
+        common.check_requested_attributes((), "/no/such/file.gpkg", None, None)
+
+    def test_known_column_passes(self):
+        common.check_requested_attributes(
+            ("LCDB_UID",), TEST_FILE_PATH, TEST_LAYER_NAME, None
+        )
+
+    def test_unknown_column_raises(self):
+        with self.assertRaises(common.UnknownAttributeError):
+            common.check_requested_attributes(
+                ("not_a_real_column",), TEST_FILE_PATH, TEST_LAYER_NAME, None
+            )
+
+
+class TestPrepareDataframeKeepAttribute(TestCase):
+    def test_keep_attribute_overrides_keep_attributes_false(self):
+        gdf = gpd.GeoDataFrame({"geometry": [Point(0, 0)], "a": [1], "b": [2]})
+        result = common._prepare_dataframe(gdf, None, False, keep_attribute=("a",))
+        self.assertEqual(sorted(result.columns), ["a", "geometry"])
+
+    def test_keep_attribute_ignores_columns_not_present(self):
+        gdf = gpd.GeoDataFrame({"geometry": [Point(0, 0)], "a": [1]})
+        result = common._prepare_dataframe(
+            gdf, None, False, keep_attribute=("a", "missing")
+        )
+        self.assertEqual(sorted(result.columns), ["a", "geometry"])
+
+    def test_no_keep_attribute_falls_back_to_boolean(self):
+        gdf = gpd.GeoDataFrame({"geometry": [Point(0, 0)], "a": [1]})
+        kept_all = common._prepare_dataframe(gdf.copy(), None, True)
+        self.assertIn("a", kept_all.columns)
+        kept_none = common._prepare_dataframe(gdf.copy(), None, False)
+        self.assertNotIn("a", kept_none.columns)
+
+    def test_keep_attribute_columns_are_dictionary_encoded(self):
+        gdf = gpd.GeoDataFrame({"geometry": [Point(0, 0)], "a": ["x"], "b": ["y"]})
+        result = common._prepare_dataframe(gdf, None, False, keep_attribute=("a",))
+        self.assertEqual(result["a"].dtype, "category")
+
+
+class TestReadBatchesColumnSelection(TestCase):
+    def test_keep_attribute_limits_columns_read(self):
+        batch = next(
+            common._read_batches(
+                TEST_FILE_PATH,
+                TEST_LAYER_NAME,
+                None,
+                False,
+                None,
+                "geometry",
+                10,
+                keep_attribute=("LCDB_UID",),
+            )
+        )
+        self.assertIn("LCDB_UID", batch.columns)
+        self.assertNotIn("Name_2018", batch.columns)
+
+    def test_default_keep_attributes_false_only_reads_geometry(self):
+        batch = next(
+            common._read_batches(
+                TEST_FILE_PATH, TEST_LAYER_NAME, None, False, None, "geometry", 10
+            )
+        )
+        self.assertEqual(list(batch.columns), ["geometry"])
 
 
 class TestDropCondition(TestCase):

--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -114,6 +114,22 @@ class TestErrors(TestRunthrough):
         with self.assertRaises(ValueError):
             indexer_instance("not_a_real_dggs")
 
+    def test_unknown_keep_attribute_raises(self):
+        with self.assertRaises(common.UnknownAttributeError):
+            h3(
+                [
+                    TEST_FILE_PATH,
+                    str(self.output_path),
+                    "--layer",
+                    TEST_LAYER_NAME,
+                    "-r",
+                    "8",
+                    "-ka",
+                    "not_a_real_column",
+                ],
+                standalone_mode=False,
+            )
+
 
 class TestIndexCompactionDefaults(TestCase):
     """Library API: index() must validate compaction requirements itself."""

--- a/tests/classes/output_validation.py
+++ b/tests/classes/output_validation.py
@@ -90,3 +90,24 @@ class TestOutputValidation(TestRunthrough):
         table = pq.read_table(self._parquet_files()[0])
         self.assertIn("Name_2018", table.schema.names)
         self.assertIn("LCDB_UID", table.schema.names)
+
+    def test_keep_attribute_restricts_to_named_columns(self):
+        """-ka limits output to exactly the requested attribute columns."""
+        self._run_h3(("-ka", "LCDB_UID"))
+        table = pq.read_table(self._parquet_files()[0])
+        self.assertIn("LCDB_UID", table.schema.names)
+        self.assertNotIn("Name_2018", table.schema.names)
+
+    def test_keep_attribute_repeated_for_multiple_columns(self):
+        """-ka can be repeated to keep several specific columns."""
+        self._run_h3(("-ka", "LCDB_UID", "-ka", "Name_2018"))
+        table = pq.read_table(self._parquet_files()[0])
+        self.assertIn("LCDB_UID", table.schema.names)
+        self.assertIn("Name_2018", table.schema.names)
+
+    def test_keep_attribute_overrides_keep_attributes_flag(self):
+        """-ka takes precedence over -k when both are given."""
+        self._run_h3(("-k", "-ka", "LCDB_UID"))
+        table = pq.read_table(self._parquet_files()[0])
+        self.assertIn("LCDB_UID", table.schema.names)
+        self.assertNotIn("Name_2018", table.schema.names)

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -38,6 +38,10 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestAvailableMemoryMb as TestAvailableMemoryMb
 with contextlib.suppress(ImportError):
+    from .classes.common_units import (
+        TestCheckRequestedAttributes as TestCheckRequestedAttributes,
+    )
+with contextlib.suppress(ImportError):
     from .classes.common_units import TestCommitOutput as TestCommitOutput
 with contextlib.suppress(ImportError):
     from .classes.common_units import (
@@ -51,6 +55,14 @@ with contextlib.suppress(ImportError):
     from .classes.common_units import TestGetParentRes as TestGetParentRes
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestStagedFileChunks as TestStagedFileChunks
+with contextlib.suppress(ImportError):
+    from .classes.common_units import (
+        TestPrepareDataframeKeepAttribute as TestPrepareDataframeKeepAttribute,
+    )
+with contextlib.suppress(ImportError):
+    from .classes.common_units import (
+        TestReadBatchesColumnSelection as TestReadBatchesColumnSelection,
+    )
 with contextlib.suppress(ImportError):
     from .classes.common_units import (
         TestWritePartitionGuards as TestWritePartitionGuards,

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -56,6 +56,14 @@ def make_dggs_command(
         help=f"Retain attributes in output. The default is to create an output that only includes {display_name} cell ID and the ID given by the -id field (or the default index ID).",
     )
     @click.option(
+        "-ka",
+        "--keep_attribute",
+        multiple=True,
+        default=(),
+        type=str,
+        help="Retain only this attribute in output; repeat for multiple. Takes precedence over -k/--keep_attributes.",
+    )
+    @click.option(
         "-crs",
         "--cut_crs",
         required=False,
@@ -141,6 +149,7 @@ def make_dggs_command(
         parent_res: str,
         id_field: str,
         keep_attributes: bool,
+        keep_attribute: tuple[str, ...],
         cut_crs: int,
         cut_threshold: float,
         threads: int,
@@ -162,6 +171,7 @@ def make_dggs_command(
 
         con, vector_input = common.db_conn_and_input_path(vector_input)
         output_directory = common.resolve_output_path(output_directory, overwrite)
+        common.check_requested_attributes(keep_attribute, vector_input, layer, con)
 
         cut_crs_obj: pyproj.CRS | None = None
         if cut_crs is not None:
@@ -185,6 +195,7 @@ def make_dggs_command(
             geo=geo,
             overwrite=overwrite,
             compact=compact,
+            keep_attribute=keep_attribute,
         )
 
     command.help = (

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -59,6 +59,12 @@ class IdFieldError(ValueError):
     pass
 
 
+class UnknownAttributeError(ValueError):
+    """Raised when -ka/--keep_attribute names a column not in the input."""
+
+    pass
+
+
 def check_resolutions(resolution: str | int, parent_res: None | str | int) -> None:
     if parent_res is not None and not int(parent_res) < int(resolution):
         raise ParentResolutionException(
@@ -70,6 +76,27 @@ def check_compaction_requirements(compact: bool, id_field: str | None) -> None:
     if compact and not id_field:
         raise IdFieldError(
             "An id_field is required for compaction, in order to handle the potential for overlapping features"
+        )
+
+
+def check_requested_attributes(
+    keep_attribute: tuple[str, ...],
+    input_file: Path | str,
+    layer: str | None,
+    con: SQLConnectionType | None,
+) -> None:
+    if not keep_attribute:
+        return
+    if layer and con:
+        with con.connect() as connection:
+            available = set(_db_table(connection, layer).columns.keys())
+    else:
+        available = set(pyogrio.read_info(str(input_file), layer=layer)["fields"])
+    unknown = [c for c in keep_attribute if c not in available]
+    if unknown:
+        raise UnknownAttributeError(
+            f"Unknown attribute(s) for -ka/--keep_attribute: {', '.join(unknown)}. "
+            f"Available: {', '.join(sorted(available))}"
         )
 
 
@@ -652,6 +679,7 @@ def _read_batches(
     id_field: str | None,
     geom_col: str,
     total: int,
+    keep_attribute: tuple[str, ...] = (),
 ):
     """
     Yield the input in GeoDataFrame batches, so peak memory is bounded by
@@ -659,14 +687,22 @@ def _read_batches(
     observed bytes-per-feature: a probe batch first, then batches sized to
     const.TARGET_BATCH_BYTES from each previous batch's footprint — so
     vertex-heavy features get proportionally smaller batches.
+
+    Only the columns actually needed (id_field, geometry, and whichever of
+    keep_attributes/keep_attribute apply) are read from the source.
     """
     rows = max(1, const.INGEST_PROBE_ROWS)
     if layer and con:
         with con.connect() as connection:
             tbl = _db_table(connection, layer)
-            if keep_attributes:
+            if keep_attribute:
+                cols = dict.fromkeys(
+                    [geom_col, *([id_field] if id_field else []), *keep_attribute]
+                )
+                stmt = sqlalchemy.select(*(tbl.c[c] for c in cols))
+            elif keep_attributes:
                 stmt = tbl.select()
-            elif id_field and not keep_attributes:
+            elif id_field:
                 stmt = sqlalchemy.select(tbl.c[id_field], tbl.c[geom_col])
             else:
                 stmt = sqlalchemy.select(tbl.c[geom_col])
@@ -683,10 +719,22 @@ def _read_batches(
                 offset += len(result)
                 rows = _next_batch_rows(result)
         return
+    if keep_attribute:
+        columns = list(
+            dict.fromkeys([*keep_attribute, *([id_field] if id_field else [])])
+        )
+    elif keep_attributes:
+        columns = None
+    else:
+        columns = [id_field] if id_field else []
     offset = 0
     while offset < total:
         batch = gpd.read_file(
-            input_file, layer=layer, skip_features=offset, max_features=rows
+            input_file,
+            layer=layer,
+            skip_features=offset,
+            max_features=rows,
+            columns=columns,
         )
         yield batch
         offset += len(batch)
@@ -723,6 +771,7 @@ def _prepare_dataframe(
     df: gpd.GeoDataFrame,
     id_field: str | None,
     keep_attributes: bool,
+    keep_attribute: tuple[str, ...] = (),
     fid_offset: int = 0,
 ) -> gpd.GeoDataFrame:
     if id_field:
@@ -730,10 +779,13 @@ def _prepare_dataframe(
     else:
         df = df.reset_index(drop=True)
         df.index = pd.RangeIndex(fid_offset, fid_offset + len(df), name="fid")
-    if not keep_attributes:
-        df = df.loc[:, ["geometry"]]
-    else:
+    if keep_attribute:
+        df = df.loc[:, [c for c in keep_attribute if c in df.columns] + ["geometry"]]
         df = _dictionary_encode_attributes(df)
+    elif keep_attributes:
+        df = _dictionary_encode_attributes(df)
+    else:
+        df = df.loc[:, ["geometry"]]
     return df
 
 
@@ -993,6 +1045,7 @@ def index(
     geo: str = const.GeoOutputMode.NONE.value,
     overwrite: bool = False,
     compact: bool = False,
+    keep_attribute: tuple[str, ...] = (),
 ) -> Path | str:
     """
     Performs multi-threaded DGGS indexing on geometries (including multipart and collections).
@@ -1024,6 +1077,7 @@ def index(
             geom_col,
             geo,
             compact,
+            keep_attribute,
         )
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
@@ -1048,6 +1102,7 @@ def _index(
     geom_col: str,
     geo: str,
     compact: bool,
+    keep_attribute: tuple[str, ...] = (),
 ) -> None:
     check_compaction_requirements(compact, id_field)
     indexer = idxfactory.indexer_instance(dggs)
@@ -1081,7 +1136,14 @@ def _index(
         part = 0
         pbar = tqdm(total=total, desc="Ingesting", unit="feature")
         for batch in _read_batches(
-            input_file, layer, con, keep_attributes, id_field, geom_col, total
+            input_file,
+            layer,
+            con,
+            keep_attributes,
+            id_field,
+            geom_col,
+            total,
+            keep_attribute,
         ):
             pbar.update(len(batch))
             if batch.crs is None:
@@ -1093,7 +1155,7 @@ def _index(
                 batch, dggs, resolution, user_cut_crs, cut_threshold
             )
             batch = _prepare_dataframe(
-                batch, id_field, keep_attributes, fid_offset=fid_offset
+                batch, id_field, keep_attributes, keep_attribute, fid_offset=fid_offset
             )
             fid_offset += len(batch)
             features_in.update(batch.index)


### PR DESCRIPTION
## Summary

\`-k/--keep_attributes\` is all-or-nothing. Adds \`-ka/--keep_attribute\` (repeatable) to select specific columns by name, taking precedence over \`-k\` when given.

- **Fail-fast validation**: requested column names are checked against the source schema (\`pyogrio.read_info\` for files, table reflection for DB input) before any real work starts, raising \`UnknownAttributeError\` on a typo rather than silently producing nothing for it.
- **Column selection pushed to the read layer**, not just filtered in-memory afterward -- \`gpd.read_file(..., columns=...)\` and the DB \`SELECT\` are both narrowed to exactly what's needed. Bonus fix bundled in: plain \`-k\`-less file input previously read every attribute column and discarded them; it now only reads \`id_field\` (+ geometry), matching what the DB path already did.

Closes #185

## Test plan
- [x] New unit tests: \`check_requested_attributes\`, \`_prepare_dataframe\`'s \`keep_attribute\` handling, \`_read_batches\`' column-selection pushdown, plus CLI-level tests (restricts to named columns, repeatable, precedence over \`-k\`, fail-fast on unknown column)
- [x] \`ruff check .\` clean
- [x] \`black --check .\` clean
- [x] \`mypy vector2dggs/\` clean
- [x] Full test suite: 214 passed
- [x] CI green on the branch before opening this PR