### PR TITLE
Share one bisection progress bar across ingest batches

### DIFF
--- a/tests/classes/bisection.py
+++ b/tests/classes/bisection.py
@@ -1,8 +1,10 @@
+import io
 from unittest import TestCase
 
 import geopandas as gpd
 import pyproj
 from shapely.geometry import Polygon
+from tqdm import tqdm
 
 from vector2dggs import common
 from vector2dggs import constants as const
@@ -45,6 +47,48 @@ class TestBisection(TestCase):
         self.assertAlmostEqual(result.geometry.iloc[1].area, square_b.area, places=6)
         # The two rows were bisected independently and must not be identical
         self.assertFalse(result.geometry.iloc[0].equals(result.geometry.iloc[1]))
+
+
+class TestSharedBisectionProgress(TestCase):
+    """
+    A pbar passed into _run_bisection is shared across calls: its total
+    grows and updates accumulate onto the same bar.
+    """
+
+    SQUARE = Polygon([(0, 0), (10, 0), (10, 10), (0, 10)])
+
+    @staticmethod
+    def _silent_pbar():
+        # disable=True would make update() a no-op; redirect output instead.
+        return tqdm(total=0, file=io.StringIO())
+
+    def test_shared_pbar_accumulates_total_and_count_across_calls(self):
+        df1 = gpd.GeoDataFrame({"geometry": [self.SQUARE]}, crs=2193)
+        df2 = gpd.GeoDataFrame({"geometry": [self.SQUARE, self.SQUARE]}, crs=2193)
+        pbar = self._silent_pbar()
+
+        _run_bisection(df1.copy(), 5.0, 1, pbar=pbar)
+        self.assertEqual(pbar.total, 1)
+        self.assertEqual(pbar.n, 1)
+
+        _run_bisection(df2.copy(), 5.0, 1, pbar=pbar)
+        self.assertEqual(pbar.total, 3)
+        self.assertEqual(pbar.n, 3)
+        pbar.close()
+
+    def test_caller_retains_ownership_of_shared_pbar(self):
+        # close() sets disable=True; staying False confirms the shared bar
+        # wasn't closed by _run_bisection itself.
+        df = gpd.GeoDataFrame({"geometry": [self.SQUARE]}, crs=2193)
+        pbar = self._silent_pbar()
+        _run_bisection(df.copy(), 5.0, 1, pbar=pbar)
+        self.assertFalse(pbar.disable)
+        pbar.close()
+
+    def test_no_pbar_given_falls_back_to_per_call_bar(self):
+        df = gpd.GeoDataFrame({"geometry": [self.SQUARE]}, crs=2193)
+        result = _run_bisection(df.copy(), 5.0, 1)
+        self.assertAlmostEqual(result.geometry.iloc[0].area, self.SQUARE.area, places=6)
 
 
 class TestBisectionPreparation(TestCase):

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -24,6 +24,10 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.bisection import TestGeodesicCutEdges as TestGeodesicCutEdges
 with contextlib.suppress(ImportError):
+    from .classes.bisection import (
+        TestSharedBisectionProgress as TestSharedBisectionProgress,
+    )
+with contextlib.suppress(ImportError):
     from .classes.compaction import TestA5CompactionBounds as TestA5CompactionBounds
 with contextlib.suppress(ImportError):
     from .classes.compaction import (

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -794,7 +794,12 @@ def _run_bisection(
     cut_threshold: None | float,
     processes: int,
     blade_segment: None | float = None,
+    pbar: tqdm | None = None,
 ) -> gpd.GeoDataFrame:
+    """
+    pbar, if given, is a shared bar whose total grows by this call's
+    oversized-feature count; otherwise a local bar is created and closed.
+    """
     LOGGER.debug("Bisecting large geometries")
     if cut_threshold is not None and cut_threshold > 0:
         # katana's own early exit is exactly this bbox-area check; computing
@@ -817,23 +822,35 @@ def _run_bisection(
         )
         if len(oversized_positions):
             geometry_loc = df.columns.get_loc("geometry")
-            with ThreadPoolExecutor(max_workers=max(1, processes)) as executor:
-                futures = [
-                    (
-                        pos,
-                        executor.submit(
-                            bisect_geometry,
-                            df.geometry.iloc[pos],
-                            cut_threshold,
-                            blade_segment,
-                        ),
-                    )
-                    for pos in oversized_positions
-                ]
-                with tqdm(total=len(futures), desc="Bisection") as pbar:
+            owns_pbar = pbar is None
+            active_pbar: tqdm = (
+                pbar
+                if pbar is not None
+                else tqdm(total=len(oversized_positions), desc="Bisection")
+            )
+            if not owns_pbar:
+                active_pbar.total = (active_pbar.total or 0) + len(oversized_positions)
+                active_pbar.refresh()
+            try:
+                with ThreadPoolExecutor(max_workers=max(1, processes)) as executor:
+                    futures = [
+                        (
+                            pos,
+                            executor.submit(
+                                bisect_geometry,
+                                df.geometry.iloc[pos],
+                                cut_threshold,
+                                blade_segment,
+                            ),
+                        )
+                        for pos in oversized_positions
+                    ]
                     for pos, future in futures:
                         df.iloc[pos, geometry_loc] = future.result()
-                        pbar.update(1)
+                        active_pbar.update(1)
+            finally:
+                if owns_pbar:
+                    active_pbar.close()
     else:
         LOGGER.debug("No bisection applied to input.")
     return df
@@ -1135,6 +1152,7 @@ def _index(
         fid_offset = 0
         part = 0
         pbar = tqdm(total=total, desc="Ingesting", unit="feature")
+        bisection_pbar = tqdm(total=0, desc="Bisection", unit="feature")
         for batch in _read_batches(
             input_file,
             layer,
@@ -1160,7 +1178,9 @@ def _index(
             fid_offset += len(batch)
             features_in.update(batch.index)
             blade_segment = _blade_segment(indexer, dggs, resolution, cut_crs)
-            batch = _run_bisection(batch, cut_threshold, processes, blade_segment)
+            batch = _run_bisection(
+                batch, cut_threshold, processes, blade_segment, bisection_pbar
+            )
             batch = _clean_geometries(batch, indexer)
             for start, end in _staged_file_chunks(
                 batch, dggs, resolution, rows_per_file
@@ -1170,6 +1190,9 @@ def _index(
                 )
                 part += 1
         pbar.close()
+        if bisection_pbar.n == 0:  # nothing bisected: don't leave an empty bar
+            bisection_pbar.leave = False
+        bisection_pbar.close()
         filepaths = [f.absolute() for f in Path(tmpdir).glob("*")]
 
         indexed_ids = _run_dggs_indexing(


### PR DESCRIPTION
## Summary

\`_run_bisection()\` runs once per ingest batch, and each call that found oversized features opened its own fresh tqdm bar scoped to just that batch. A large input split into many batches (adaptive sizing) produced one full "Bisection: 0%->100%" bar per batch -- noisy, especially once redirected to a non-interactive log (tqdm can't overwrite its line in place there, so every incremental update becomes its own line).

\`_run_bisection\` now accepts an optional shared \`pbar\`; when given, it grows the bar's total as more oversized features are discovered across batches and updates the same bar, instead of opening/closing its own. \`_index()\` creates one bisection bar alongside the existing "Ingesting" bar and passes it through, hiding it on close if it never actually advanced (e.g. every feature was already under the area threshold at a coarse resolution) so a run needing no bisection stays silent.

Closes #186

## Test plan
- [x] New unit tests: shared pbar accumulates total/count across calls, caller retains ownership (not closed by \`_run_bisection\`), fallback to a local bar when none is given
- [x] \`ruff check .\` clean
- [x] \`black --check .\` clean
- [x] \`mypy vector2dggs/\` clean
- [x] Full test suite: 205 passed
- [x] CI green on the branch before opening this PR