### PR TITLE
scripts/bump.sh: push and draft a GitHub release automatically

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ Releases are published to [PyPI](https://pypi.org/project/vector2dggs/) automati
 
 ## Making a release
 
-1. **Bump the version** — run the bump script, which updates `pyproject.toml`, `poetry.lock`, and `CITATION.cff` atomically and commits:
+1. **Bump the version** — run the bump script, which updates `pyproject.toml`, `poetry.lock`, and `CITATION.cff` atomically, commits, pushes, and drafts a GitHub Release (tag + auto-generated notes from merged PRs since the last release):
 
    ```bash
    scripts/bump.sh patch   # 0.13.1 → 0.13.2
@@ -14,19 +14,14 @@ Releases are published to [PyPI](https://pypi.org/project/vector2dggs/) automati
    scripts/bump.sh major   # 0.13.1 → 1.0.0
    ```
 
-2. **Push:**
-
-   ```bash
-   git push
-   ```
-
-3. **Create a GitHub Release:**
-   - Go to the repository on GitHub → Releases → **Draft a new release**
-   - Create a new tag matching the version: `v0.9.1` (the tag is created at this point — do not push it manually beforehand)
-   - Write release notes summarising changes
+2. **Review and publish the draft release:**
+   - Go to the repository on GitHub → Releases, and open the draft the script created
+   - Check the auto-generated notes, editing if needed
    - Click **Publish release**
 
-4. The [`publish.yml`](.github/workflows/publish.yml) workflow triggers automatically, builds the distributions, and uploads them to PyPI. No further action is required.
+3. The [`publish.yml`](.github/workflows/publish.yml) workflow triggers automatically, builds the distributions, and uploads them to PyPI. No further action is required.
+
+The release is left as a draft deliberately: `publish.yml` only triggers on a *published* release, so this is the checkpoint before the (irreversible) PyPI upload. To publish from the command line instead of the UI: `gh release edit vX.Y.Z --draft=false`.
 
 ## How it works
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Usage: scripts/bump.sh <patch|minor|major>
-# Bumps the version in pyproject.toml, updates CITATION.cff, and commits.
+# Bumps the version in pyproject.toml, updates CITATION.cff, commits,
+# pushes, and drafts a GitHub release with auto-generated notes.
 set -euo pipefail
 
 PART=${1:-}
@@ -11,13 +12,20 @@ fi
 
 poetry version "$PART"
 VERSION=$(poetry version -s)
+TAG="v$VERSION"
 TODAY=$(date +%F)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 sed -i "s/^version: .*/version: \"$VERSION\"/" CITATION.cff
 sed -i "s/^date-released: .*/date-released: \"$TODAY\"/" CITATION.cff
 
 git add pyproject.toml poetry.lock CITATION.cff
 git commit -m "version bump to $VERSION"
+git push origin "$BRANCH"
+
+gh release create "$TAG" --target "$BRANCH" --draft --generate-notes --title "$TAG"
 
 echo ""
-echo "Bumped to $VERSION. Next: push, then publish a GitHub Release tagged v$VERSION."
+echo "Bumped to $VERSION, pushed, and drafted release $TAG."
+echo "Review the auto-generated notes, then publish to trigger the PyPI upload:"
+echo "  gh release edit $TAG --draft=false"


### PR DESCRIPTION
## Summary

\`RELEASE.md\`'s process required three manual steps after \`scripts/bump.sh\`: push, then go to the GitHub UI to draft a release (creating the tag, writing notes by hand, publishing).

\`bump.sh\` now also pushes and creates the release itself, using GitHub's auto-generated notes (from merged PRs since the previous tag) instead of hand-written ones. Left as a **draft**, not published immediately: \`publish.yml\` only triggers on a published release, so this keeps a manual checkpoint before the irreversible PyPI upload while still automating the tedious tag/notes preparation.

Closes #189

## Test plan

No Python source touched (shell script + docs only); \`bash -n scripts/bump.sh\` syntax-checks clean. The script itself wasn't executed (would push/create a real release) -- reviewed by inspection instead.