### PR TITLE
Support id_field naming a GPKG FID/PK column

### DIFF
--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -5,6 +5,7 @@ from unittest import TestCase, mock
 
 import geopandas as gpd
 import pandas as pd
+import pyogrio
 from shapely.geometry import Point, box
 
 import vector2dggs.constants as const
@@ -165,6 +166,103 @@ class TestReadBatchesColumnSelection(TestCase):
             )
         )
         self.assertEqual(list(batch.columns), ["geometry"])
+
+
+class TestFidColumnIdField(TestCase):
+    """
+    Reproduces issue #191: Kart working copies (and any GPKG built with a
+    custom FID column name) promote the dataset's own PK to the GPKG
+    FID slot rather than exposing it as a regular field. -id/--id_field
+    pointing at that slot needs fid_as_index, since it's absent from both
+    pyogrio's "fields" list and a plain columns= read.
+    """
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.gpkg_path = str(Path(self._tmpdir.name) / "kart_style.gpkg")
+        gdf = gpd.GeoDataFrame(
+            {
+                "facility_id": [101, 102, 103],
+                "name": ["a", "b", "c"],
+                "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+            },
+            crs="EPSG:4326",
+        )
+        pyogrio.write_dataframe(
+            gdf,
+            self.gpkg_path,
+            layer="facilities",
+            layer_options={"FID": "facility_id"},
+        )
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_fid_column_is_detected(self):
+        self.assertEqual(
+            common._fid_column(self.gpkg_path, "facilities"), "facility_id"
+        )
+
+    def test_fid_column_excluded_from_fields(self):
+        info = pyogrio.read_info(self.gpkg_path, layer="facilities")
+        self.assertNotIn("facility_id", info["fields"])
+
+    def test_check_id_field_accepts_fid_column(self):
+        common.check_id_field("facility_id", self.gpkg_path, "facilities", None)
+
+    def test_check_id_field_accepts_regular_field(self):
+        common.check_id_field("name", self.gpkg_path, "facilities", None)
+
+    def test_check_id_field_rejects_unknown_field(self):
+        with self.assertRaises(common.IdFieldError):
+            common.check_id_field(
+                "not_a_real_column", self.gpkg_path, "facilities", None
+            )
+
+    def test_read_batches_recovers_fid_column_values(self):
+        batch = next(
+            common._read_batches(
+                self.gpkg_path,
+                "facilities",
+                None,
+                False,
+                "facility_id",
+                "geometry",
+                3,
+            )
+        )
+        self.assertIn("facility_id", batch.columns)
+        self.assertEqual(sorted(batch["facility_id"]), [101, 102, 103])
+
+    def test_read_batches_regular_id_field_unaffected(self):
+        batch = next(
+            common._read_batches(
+                self.gpkg_path,
+                "facilities",
+                None,
+                False,
+                "name",
+                "geometry",
+                3,
+            )
+        )
+        self.assertIn("name", batch.columns)
+
+    def test_prepare_dataframe_indexes_by_recovered_fid(self):
+        batch = next(
+            common._read_batches(
+                self.gpkg_path,
+                "facilities",
+                None,
+                False,
+                "facility_id",
+                "geometry",
+                3,
+            )
+        )
+        result = common._prepare_dataframe(batch, "facility_id", False)
+        self.assertEqual(result.index.name, "facility_id")
+        self.assertEqual(sorted(result.index), [101, 102, 103])
 
 
 class TestDropCondition(TestCase):

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -56,6 +56,8 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestDropCondition as TestDropCondition
 with contextlib.suppress(ImportError):
+    from .classes.common_units import TestFidColumnIdField as TestFidColumnIdField
+with contextlib.suppress(ImportError):
     from .classes.common_units import TestGetParentRes as TestGetParentRes
 with contextlib.suppress(ImportError):
     from .classes.common_units import TestStagedFileChunks as TestStagedFileChunks

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -172,6 +172,7 @@ def make_dggs_command(
         con, vector_input = common.db_conn_and_input_path(vector_input)
         output_directory = common.resolve_output_path(output_directory, overwrite)
         common.check_requested_attributes(keep_attribute, vector_input, layer, con)
+        common.check_id_field(id_field, vector_input, layer, con)
 
         cut_crs_obj: pyproj.CRS | None = None
         if cut_crs is not None:

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -100,6 +100,37 @@ def check_requested_attributes(
         )
 
 
+def _fid_column(input_file: Path | str, layer: str | None) -> str | None:
+    """
+    The name of the file's FID/primary-key slot, e.g. "fid" for a plain
+    GPKG, or a dataset-specific name for a Kart working copy that promotes
+    its own PK there. Returns None if the format has no FID concept, or
+    the file has none set.
+    """
+    return pyogrio.read_info(str(input_file), layer=layer).get("fid_column") or None
+
+
+def check_id_field(
+    id_field: str | None,
+    input_file: Path | str,
+    layer: str | None,
+    con: SQLConnectionType | None,
+) -> None:
+    if not id_field:
+        return
+    if layer and con:
+        with con.connect() as connection:
+            available = set(_db_table(connection, layer).columns.keys())
+    else:
+        info = pyogrio.read_info(str(input_file), layer=layer)
+        available = set(info["fields"]) | {info.get("fid_column")}
+    if id_field not in available:
+        raise IdFieldError(
+            f"Unknown -id/--id_field '{id_field}'. "
+            f"Available: {', '.join(sorted(c for c in available if c))}"
+        )
+
+
 def validate_compression(ctx, param, value: str) -> str:
     """
     Click callback that fails fast on an unsupported Parquet compression
@@ -689,7 +720,11 @@ def _read_batches(
     vertex-heavy features get proportionally smaller batches.
 
     Only the columns actually needed (id_field, geometry, and whichever of
-    keep_attributes/keep_attribute apply) are read from the source.
+    keep_attributes/keep_attribute apply) are read from the source. When
+    id_field names the file's FID/primary-key slot (e.g. Kart working
+    copies, which promote the dataset PK there) rather than a regular
+    field, it's read via fid_as_index instead of columns=, since a FID
+    slot never appears in either.
     """
     rows = max(1, const.INGEST_PROBE_ROWS)
     if layer and con:
@@ -719,14 +754,17 @@ def _read_batches(
                 offset += len(result)
                 rows = _next_batch_rows(result)
         return
+    id_is_fid = bool(id_field) and id_field == _fid_column(input_file, layer)
     if keep_attribute:
         columns = list(
-            dict.fromkeys([*keep_attribute, *([id_field] if id_field else [])])
+            dict.fromkeys(
+                [*keep_attribute, *([id_field] if id_field and not id_is_fid else [])]
+            )
         )
     elif keep_attributes:
         columns = None
     else:
-        columns = [id_field] if id_field else []
+        columns = [id_field] if id_field and not id_is_fid else []
     offset = 0
     while offset < total:
         batch = gpd.read_file(
@@ -735,7 +773,10 @@ def _read_batches(
             skip_features=offset,
             max_features=rows,
             columns=columns,
+            fid_as_index=id_is_fid,
         )
+        if id_is_fid:
+            batch = batch.rename_axis(id_field).reset_index()
         yield batch
         offset += len(batch)
         rows = _next_batch_rows(batch)


### PR DESCRIPTION
Kart working copies (and any GPKG built with a custom FID column name) promote the dataset's PK to the GPKG FID slot rather than exposing it as a regular field. `pyogrio` silently drops `columns=` names it can't find there, so `-id/--id_field` pointing at that slot previously produced a dataframe missing the column entirely, surfacing as a cryptic downstream `KeyError` in `_prepare_dataframe`.

## Fix

- `_read_batches` now detects when `id_field` matches the file's `fid_column` (via `pyogrio.read_info`) and reads with `fid_as_index=True` instead, recovering the real FID values and renaming the index back to `id_field`.
- New `check_id_field()` validator fails fast with a clear message when `id_field` names neither a regular field nor the FID column, mirroring the existing `check_requested_attributes()` pattern.
- DB/PostGIS input is unaffected — SQLAlchemy reflection already exposes the PK as a normal column.
- Handles the Shapefile-style case where `fid_column` is `""` (FID not physically stored) — `"" or None` already normalises that to "no FID column detected".

## Testing

- New `TestFidColumnIdField` test class reproduces the exact Kart-style scenario (GPKG built via `pyogrio.write_dataframe(..., layer_options={"FID": "facility_id"})`), covering FID detection, `check_id_field` accept/reject cases, `_read_batches` recovering real values, and non-regression for a normal (non-FID) `id_field`.
- Manually reproduced the original crash end-to-end via the CLI (`vector2dggs h3 -id facility_id ...`) against a Kart-style GPKG, confirmed it completes and the output contains real `facility_id` values (previously crashed with `KeyError`).
- Manually confirmed `check_id_field` fails fast with a clear message for a genuinely unknown `-id` value.
- Full test suite: 245 passed.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)