### PR TITLE
Prefer a real internal ID over a synthetic one; drop leaked index column

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ vector2dggs <dggs> [OPTIONS] VECTOR_INPUT OUTPUT_DIRECTORY
 
 - `-r`/`--resolution`: the target DGGS resolution. Each output row is one (feature, cell) pair; a cell is included when its centre falls inside the feature, uniformly across all backends.
 - `-pr`/`--parent_res`: a coarser resolution used to partition the output (hive directories such as `h3_03=…`); defaults to a fixed offset below the target resolution.
-- `-id`/`--id_field`: the feature identifier carried into the output. Defaults to the input's own internal ID where one exists (a GPKG's FID column, or a DB table's single-column primary key); otherwise falls back to a synthetic index, which is not stable across runs. Rows sharing an id are treated as one feature.
-- `-co`/`--compact` (requires an id, explicit or auto-detected): merges complete sets of sibling cells belonging to one feature, to no coarser than the parent resolution. Compacted output expands back to exactly the full-resolution result.
+- `-id`/`--id_field`: the feature identifier carried into the output. Defaults to the input's own internal ID where one exists (a GPKG's FID column, or a DB table's single-column primary key); otherwise falls back to a synthetic index tied to row position in the read order — stable across repeated runs of the same unchanged input, but not portable to a different export/copy of the same data. Rows sharing an id are treated as one feature.
+- `-co`/`--compact`: merges complete sets of sibling cells belonging to one feature (grouped by whichever id_field is in play, explicit, auto-detected, or synthetic), to no coarser than the parent resolution. Compacted output expands back to exactly the full-resolution result.
 - `--geo`: plain Parquet by default; `point` or `polygon` writes GeoParquet (v1.1.0) cell geometries instead.
 
 The full reference (`vector2dggs h3 --help`; the other commands differ only in their resolution ranges):
@@ -124,7 +124,8 @@ Options:
                                   control where this data will be written.
                                   [default: (system temp dir)]
   -co, --compact                  Compact the H3 cells up to the parent
-                                  resolution. Compaction requires an id_field.
+                                  resolution, grouping by id_field (explicit,
+                                  auto-detected, or the default 0...n sequence).
   -o, --overwrite
   --version                       Show the version and exit.
   --help                          Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ vector2dggs <dggs> [OPTIONS] VECTOR_INPUT OUTPUT_DIRECTORY
 
 - `-r`/`--resolution`: the target DGGS resolution. Each output row is one (feature, cell) pair; a cell is included when its centre falls inside the feature, uniformly across all backends.
 - `-pr`/`--parent_res`: a coarser resolution used to partition the output (hive directories such as `h3_03=…`); defaults to a fixed offset below the target resolution.
-- `-id`/`--id_field`: the feature identifier carried into the output; defaults to a synthetic index. Rows sharing an id are treated as one feature.
-- `-co`/`--compact` (requires `-id`): merges complete sets of sibling cells belonging to one feature, to no coarser than the parent resolution. Compacted output expands back to exactly the full-resolution result.
+- `-id`/`--id_field`: the feature identifier carried into the output. Defaults to the input's own internal ID where one exists (a GPKG's FID column, or a DB table's single-column primary key); otherwise falls back to a synthetic index, which is not stable across runs. Rows sharing an id are treated as one feature.
+- `-co`/`--compact` (requires an id, explicit or auto-detected): merges complete sets of sibling cells belonging to one feature, to no coarser than the parent resolution. Compacted output expands back to exactly the full-resolution result.
 - `--geo`: plain Parquet by default; `point` or `polygon` writes GeoParquet (v1.1.0) cell geometries instead.
 
 The full reference (`vector2dggs h3 --help`; the other commands differ only in their resolution ranges):
@@ -73,8 +73,11 @@ Options:
   -pr, --parent_res [0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15]
                                   H3 parent resolution for the output partition.
                                   Defaults to resolution - 6
-  -id, --id_field TEXT            Field to use as an ID; defaults to a
-                                  constructed single 0...n index on the original
+  -id, --id_field TEXT            Field to use as an ID; defaults to the input's
+                                  own internal ID if it has one (e.g. a GPKG's
+                                  FID column, or a DB table's single-column
+                                  primary key), otherwise falls back to a
+                                  constructed 0...n index on the original
                                   feature order.
   -k, --keep_attributes           Retain attributes in output. The default is to
                                   create an output that only includes H3 cell ID

--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -264,6 +264,38 @@ class TestFidColumnIdField(TestCase):
         self.assertEqual(result.index.name, "facility_id")
         self.assertEqual(sorted(result.index), [101, 102, 103])
 
+    def test_resolve_default_id_field_uses_fid_column(self):
+        self.assertEqual(
+            common.resolve_default_id_field(self.gpkg_path, "facilities", None),
+            "facility_id",
+        )
+
+
+class TestResolveDefaultIdFieldNoFid(TestCase):
+    """
+    Formats without a physically-stored FID (e.g. Shapefile) have nothing
+    for resolve_default_id_field to auto-detect: it falls back to None
+    (the caller's synthetic-sequence path), with a warning logged so
+    users understand IDs won't be stable across runs.
+    """
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.shp_path = str(Path(self._tmpdir.name) / "no_fid.shp")
+        gdf = gpd.GeoDataFrame(
+            {"name": ["a", "b"], "geometry": [Point(0, 0), Point(1, 1)]},
+            crs="EPSG:4326",
+        )
+        gdf.to_file(self.shp_path)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_falls_back_to_none(self):
+        with self.assertLogs(common.LOGGER, level="WARNING"):
+            result = common.resolve_default_id_field(self.shp_path, None, None)
+        self.assertIsNone(result)
+
 
 class TestDropCondition(TestCase):
     def test_small_drop_logs_info(self):

--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 
 import click
 import geopandas as gpd
+import pyarrow.parquet as pq
 from pyogrio.errors import DataLayerError
 from shapely.geometry import Polygon
 
@@ -112,20 +113,22 @@ class TestErrors(TestRunthrough):
         )
         self.assertTrue(any(Path(self.output_path).rglob("*.parquet")))
 
-    def test_compact_without_any_usable_id_raises(self):
+    def test_compact_without_any_usable_id_uses_synthetic_fid(self):
         """A format with no physically-stored FID (e.g. Shapefile) and no
-        -id given: compaction still has no real id_field to fall back on."""
+        -id given: compaction still proceeds, grouped by the synthetic fid
+        (stable across runs of this same file, just not a real identity)."""
         with tempfile.TemporaryDirectory() as tmp:
             shp = f"{tmp}/no_fid.shp"
             gdf = gpd.read_file(TEST_FILE_PATH, layer=TEST_LAYER_NAME)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 gdf.to_file(shp)
-            with self.assertRaises(common.IdFieldError):
-                h3(
-                    [shp, str(self.output_path), "-r", "8", "-co"],
-                    standalone_mode=False,
-                )
+            h3(
+                [shp, str(self.output_path), "-r", "8", "-co"],
+                standalone_mode=False,
+            )
+        table = pq.read_table(next(Path(self.output_path).rglob("*.parquet")))
+        self.assertIn("fid", table.schema.names)
 
     def test_unknown_dggs_raises(self):
         with self.assertRaises(ValueError):
@@ -192,9 +195,9 @@ class TestIndexCompactionDefaults(TestCase):
         out = self._index(compact=True)
         self.assertTrue(any(Path(out).rglob("*.parquet")))
 
-    def test_compact_without_any_usable_id_raises_idfielderror(self):
+    def test_compact_without_any_usable_id_uses_synthetic_fid(self):
         """A format with no physically-stored FID (e.g. Shapefile) and no
-        id_field: index() itself must still refuse compact, not just the CLI."""
+        id_field: index() still compacts, grouped by the synthetic fid."""
         shp = f"{self._tmp.name}/in.shp"
         df = gpd.GeoDataFrame(
             {
@@ -207,18 +210,18 @@ class TestIndexCompactionDefaults(TestCase):
             crs=4326,
         )
         df.to_file(shp)
-        with self.assertRaises(common.IdFieldError):
-            common.index(
-                "h3",
-                shp,
-                f"{self._tmp.name}/out2.pq",
-                7,
-                None,
-                False,
-                0.0,
-                1,
-                compact=True,
-            )
+        out = common.index(
+            "h3",
+            shp,
+            f"{self._tmp.name}/out2.pq",
+            7,
+            None,
+            False,
+            0.0,
+            1,
+            compact=True,
+        )
+        self.assertTrue(any(Path(out).rglob("*.parquet")))
 
     def test_compaction_defaults_off(self):
         out = self._index()

--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -95,20 +95,37 @@ class TestErrors(TestRunthrough):
                 standalone_mode=False,
             )
 
-    def test_compact_without_id_field_raises(self):
-        with self.assertRaises(common.IdFieldError):
-            h3(
-                [
-                    TEST_FILE_PATH,
-                    str(self.output_path),
-                    "--layer",
-                    TEST_LAYER_NAME,
-                    "-r",
-                    "8",
-                    "-co",
-                ],
-                standalone_mode=False,
-            )
+    def test_compact_without_id_field_uses_autodetected_fid(self):
+        """The fixture GPKG has a physically-stored FID column, so -co
+        without -id now succeeds via auto-detection rather than raising."""
+        h3(
+            [
+                TEST_FILE_PATH,
+                str(self.output_path),
+                "--layer",
+                TEST_LAYER_NAME,
+                "-r",
+                "8",
+                "-co",
+            ],
+            standalone_mode=False,
+        )
+        self.assertTrue(any(Path(self.output_path).rglob("*.parquet")))
+
+    def test_compact_without_any_usable_id_raises(self):
+        """A format with no physically-stored FID (e.g. Shapefile) and no
+        -id given: compaction still has no real id_field to fall back on."""
+        with tempfile.TemporaryDirectory() as tmp:
+            shp = f"{tmp}/no_fid.shp"
+            gdf = gpd.read_file(TEST_FILE_PATH, layer=TEST_LAYER_NAME)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                gdf.to_file(shp)
+            with self.assertRaises(common.IdFieldError):
+                h3(
+                    [shp, str(self.output_path), "-r", "8", "-co"],
+                    standalone_mode=False,
+                )
 
     def test_unknown_dggs_raises(self):
         with self.assertRaises(ValueError):
@@ -168,9 +185,40 @@ class TestIndexCompactionDefaults(TestCase):
             **kwargs,
         )
 
-    def test_compact_without_id_field_raises_idfielderror(self):
+    def test_compact_without_id_field_uses_autodetected_fid(self):
+        """The fixture GPKG has a physically-stored FID column, so compact
+        without id_field now succeeds via auto-detection rather than
+        raising, matching the CLI's behaviour."""
+        out = self._index(compact=True)
+        self.assertTrue(any(Path(out).rglob("*.parquet")))
+
+    def test_compact_without_any_usable_id_raises_idfielderror(self):
+        """A format with no physically-stored FID (e.g. Shapefile) and no
+        id_field: index() itself must still refuse compact, not just the CLI."""
+        shp = f"{self._tmp.name}/in.shp"
+        df = gpd.GeoDataFrame(
+            {
+                "geometry": [
+                    Polygon(
+                        [(174.7, -41.3), (174.9, -41.3), (174.9, -41.2), (174.7, -41.2)]
+                    )
+                ]
+            },
+            crs=4326,
+        )
+        df.to_file(shp)
         with self.assertRaises(common.IdFieldError):
-            self._index(compact=True)
+            common.index(
+                "h3",
+                shp,
+                f"{self._tmp.name}/out2.pq",
+                7,
+                None,
+                False,
+                0.0,
+                1,
+                compact=True,
+            )
 
     def test_compaction_defaults_off(self):
         out = self._index()

--- a/tests/classes/output_validation.py
+++ b/tests/classes/output_validation.py
@@ -111,3 +111,27 @@ class TestOutputValidation(TestRunthrough):
         table = pq.read_table(self._parquet_files()[0])
         self.assertIn("LCDB_UID", table.schema.names)
         self.assertNotIn("Name_2018", table.schema.names)
+
+    def test_no_stray_index_column(self):
+        """No leaked "index" column, with or without an explicit id_field."""
+        self._run_h3()
+        self.assertNotIn("index", pq.read_table(self._parquet_files()[0]).schema.names)
+        self._run_h3(("-id", "LCDB_UID", "-o"))
+        self.assertNotIn("index", pq.read_table(self._parquet_files()[0]).schema.names)
+
+    def test_default_id_uses_real_fid_not_synthetic(self):
+        """
+        No -id given, but the GPKG has a physically-stored FID column:
+        auto-detected and used, rather than a fresh 0...n sequence. The
+        fixture's real FIDs start at 1 (never 0).
+        """
+        self._run_h3()
+        df = pq.read_table(self._parquet_files()[0]).to_pandas()
+        self.assertIn("fid", df.columns)
+        self.assertNotIn(0, set(df["fid"]))
+
+    def test_compaction_without_explicit_id_uses_autodetected_fid(self):
+        """-co works without -id, since a real FID is auto-detected to satisfy it."""
+        self._run_h3(("-co",))
+        table = pq.read_table(self._parquet_files()[0])
+        self.assertIn("fid", table.schema.names)

--- a/tests/classes/postgis.py
+++ b/tests/classes/postgis.py
@@ -120,3 +120,83 @@ class TestPostGIS(TestRunthrough):
         table = pq.read_table(files[0])
         self.assertIn("LCDB_UID", table.schema.names)
         self.assertNotIn("Name_2018", table.schema.names)
+
+    def _table_with_primary_key(
+        self, table_name: str, extra_pk_columns: tuple[str, ...] = ()
+    ) -> None:
+        """
+        Writes the fixture with its pandas RangeIndex as a "row_pk" column
+        (genuinely unique by construction, unlike LCDB_UID: several source
+        rows legitimately share one feature id), then makes that column
+        (plus any extra_pk_columns, for a composite key) the table's PK.
+        """
+        engine = sqlalchemy.create_engine(self.connection_url)
+        try:
+            gdf = gpd.read_file(TEST_FILE_PATH, layer=TEST_LAYER_NAME)
+            gdf.to_postgis(
+                table_name,
+                engine,
+                if_exists="replace",
+                index=True,
+                index_label="row_pk",
+            )
+            cols = ", ".join(f'"{c}"' for c in ("row_pk", *extra_pk_columns))
+            with engine.begin() as connection:
+                connection.execute(
+                    sqlalchemy.text(
+                        f'ALTER TABLE "{table_name}" ADD PRIMARY KEY ({cols})'
+                    )
+                )
+        finally:
+            engine.dispose()
+
+    def test_postgis_default_id_uses_primary_key(self):
+        """No -id given, but the table has a single-column PK: auto-detected
+        and used, rather than falling back to a synthetic fid."""
+        table_name = "vector2dggs_test_pk_table"
+        self._table_with_primary_key(table_name)
+        h3(
+            [
+                self.connection_url,
+                str(self.output_path),
+                "--layer",
+                table_name,
+                "-g",
+                "geometry",
+                "-r",
+                "8",
+                "-t",
+                "1",
+            ],
+            standalone_mode=False,
+        )
+        files = sorted(self.output_path.rglob("*.parquet"))
+        self.assertTrue(files, "No parquet files written from PostGIS input")
+        table = pq.read_table(files[0])
+        self.assertIn("row_pk", table.schema.names)
+        self.assertNotIn("fid", table.schema.names)
+
+    def test_postgis_composite_primary_key_falls_back_to_synthetic(self):
+        """A composite PK isn't auto-detected (out of scope for #193, see
+        #194); falls back to the synthetic fid, same as no PK at all."""
+        table_name = "vector2dggs_test_composite_pk_table"
+        self._table_with_primary_key(table_name, extra_pk_columns=("LCDB_UID",))
+        h3(
+            [
+                self.connection_url,
+                str(self.output_path),
+                "--layer",
+                table_name,
+                "-g",
+                "geometry",
+                "-r",
+                "8",
+                "-t",
+                "1",
+            ],
+            standalone_mode=False,
+        )
+        files = sorted(self.output_path.rglob("*.parquet"))
+        self.assertTrue(files, "No parquet files written from PostGIS input")
+        table = pq.read_table(files[0])
+        self.assertIn("fid", table.schema.names)

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -71,6 +71,10 @@ with contextlib.suppress(ImportError):
     )
 with contextlib.suppress(ImportError):
     from .classes.common_units import (
+        TestResolveDefaultIdFieldNoFid as TestResolveDefaultIdFieldNoFid,
+    )
+with contextlib.suppress(ImportError):
+    from .classes.common_units import (
         TestWritePartitionGuards as TestWritePartitionGuards,
     )
 with contextlib.suppress(ImportError):

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -138,7 +138,7 @@ def make_dggs_command(
         "-co",
         "--compact",
         is_flag=True,
-        help=f"Compact the {display_name} cells up to the parent resolution. Compaction requires an id_field.",
+        help=f"Compact the {display_name} cells up to the parent resolution, grouping by id_field (explicit, auto-detected, or the default 0...n sequence).",
     )
     @click.option("-o", "--overwrite", is_flag=True)
     @click.version_option(version=__version__)

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -44,7 +44,7 @@ def make_dggs_command(
         required=False,
         default=const.DEFAULTS["id"],
         type=str,
-        help="Field to use as an ID; defaults to a constructed single 0...n index on the original feature order.",
+        help="Field to use as an ID; defaults to the input's own internal ID if it has one (e.g. a GPKG's FID column, or a DB table's single-column primary key), otherwise falls back to a constructed 0...n index on the original feature order.",
         nargs=1,
     )
     @click.option(
@@ -147,7 +147,7 @@ def make_dggs_command(
         output_directory: str | Path,
         resolution: str,
         parent_res: str,
-        id_field: str,
+        id_field: str | None,
         keep_attributes: bool,
         keep_attribute: tuple[str, ...],
         cut_crs: int,
@@ -165,7 +165,6 @@ def make_dggs_command(
         common.raise_rlimit_nofile()
 
         common.check_resolutions(resolution, parent_res)
-        common.check_compaction_requirements(compact, id_field)
 
         geo = const.GeoOutputMode(geo).value
 

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -131,6 +131,36 @@ def check_id_field(
         )
 
 
+def resolve_default_id_field(
+    input_file: Path | str,
+    layer: str | None,
+    con: SQLConnectionType | None,
+) -> str | None:
+    """
+    When -id/--id_field isn't given, prefer a real internal ID over a
+    constructed 0...n sequence: a file's physically-stored FID column, or
+    a DB table's single-column primary key. Falls back to None (the
+    caller's synthetic-sequence path) with a warning when neither is
+    available, e.g. Shapefile, or a composite/missing DB primary key.
+    """
+    if layer and con:
+        with con.connect() as connection:
+            pk_cols = list(_db_table(connection, layer).primary_key.columns)
+        if len(pk_cols) == 1:
+            return pk_cols[0].name
+    else:
+        fid_col = _fid_column(input_file, layer)
+        if fid_col:
+            return fid_col
+    LOGGER.warning(
+        "No internal ID found (no physically-stored FID column, or no "
+        "single-column primary key); using a constructed 0...n index, "
+        "which is not stable across runs. Pass -id/--id_field to use a "
+        "specific field instead."
+    )
+    return None
+
+
 def validate_compression(ctx, param, value: str) -> str:
     """
     Click callback that fails fast on an unsupported Parquet compression
@@ -554,7 +584,11 @@ def _polyfill(
     cells hive-partitioned by parent cell directly into the output
     directory. Returns the ids of features that produced at least one cell.
     """
-    df = gpd.read_parquet(pq_in).reset_index()
+    # id_col is already a plain column by this point (_clean_geometries put
+    # it there), so no reset_index() here: the staged file's own index is a
+    # meaningless post-explode position, and materialising it would leak a
+    # stray "index" column into every output row.
+    df = gpd.read_parquet(pq_in)
     if df.empty:
         return np.array([])
 
@@ -1162,6 +1196,7 @@ def _index(
     compact: bool,
     keep_attribute: tuple[str, ...] = (),
 ) -> None:
+    id_field = id_field or resolve_default_id_field(input_file, layer, con)
     check_compaction_requirements(compact, id_field)
     indexer = idxfactory.indexer_instance(dggs)
     parent_res = get_parent_res(dggs, parent_res, resolution)

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -72,13 +72,6 @@ def check_resolutions(resolution: str | int, parent_res: None | str | int) -> No
         )
 
 
-def check_compaction_requirements(compact: bool, id_field: str | None) -> None:
-    if compact and not id_field:
-        raise IdFieldError(
-            "An id_field is required for compaction, in order to handle the potential for overlapping features"
-        )
-
-
 def check_requested_attributes(
     keep_attribute: tuple[str, ...],
     input_file: Path | str,
@@ -154,9 +147,10 @@ def resolve_default_id_field(
             return fid_col
     LOGGER.warning(
         "No internal ID found (no physically-stored FID column, or no "
-        "single-column primary key); using a constructed 0...n index, "
-        "which is not stable across runs. Pass -id/--id_field to use a "
-        "specific field instead."
+        "single-column primary key); using a constructed 0...n index tied "
+        "to row position in the read order, which won't match a different "
+        "export/copy of this data. Pass -id/--id_field to use a specific "
+        "field instead."
     )
     return None
 
@@ -1197,7 +1191,6 @@ def _index(
     keep_attribute: tuple[str, ...] = (),
 ) -> None:
     id_field = id_field or resolve_default_id_field(input_file, layer, con)
-    check_compaction_requirements(compact, id_field)
     indexer = idxfactory.indexer_instance(dggs)
     parent_res = get_parent_res(dggs, parent_res, resolution)
 
@@ -1303,7 +1296,7 @@ def _index(
             output_directory,
             resolution,
             parent_res,
-            id_field,
+            id_field or "fid",
             compact,
             geo,
             compression,


### PR DESCRIPTION
Recreates #195, which GitHub auto-closed when its base branch (`fix/191-fid-column-id-field`, PR #192) was deleted on merge — this targets `main` directly instead. Same content, unchanged.

## Two related default-behaviour fixes for when `-id/--id_field` isn't given

**1. Prefer a real internal ID over a synthetic sequence.** Previously, no `-id` always meant a constructed `0...n` sequential ID. That discarded a real, stable ID whenever one already existed. `common.resolve_default_id_field()` now prefers:
- a file's physically-stored FID column (`pyogrio.read_info()["fid_column"]`, added for #191), or
- a DB table's single-column primary key (via SQLAlchemy reflection),

falling back to the synthetic sequence — with a logged warning — only when neither is available (Shapefile, or a composite/missing DB primary key; composite-key support is intentionally out of scope here, tracked in #194).

This lives in `common._index()` itself, not just the CLI wrapper, so library callers of `common.index()` get the same behaviour.

⚠️ **Behaviour change**: this affects effectively all GPKG input, not just Kart-style working copies — a plain GPKG's FID column is conventionally also named `fid`, so the output *column name* is usually unchanged, but *values* shift from a 0-based read-order sequence to the file's real (often 1-based, possibly gapped) physical FIDs.

**2. Drop a stray leaked `index` column.** `_polyfill()` did `gpd.read_parquet(pq_in).reset_index()` on every staged file, materialising a meaningless leftover positional index as a literal `index` column in every run's output, regardless of `id_field`. Fixed by dropping the redundant `reset_index()` call.

**3. `-co/--compact` no longer requires a real ID.** It now proceeds using the synthetic per-run `fid` when nothing better is available, since that ID is assigned once per original row before bisection/explode and correctly identifies which cells belong to which feature — the actual property compaction needs. It's deterministic across repeated runs of the same unchanged input (tied to row position, so it won't match a different export/copy of the same data — a caveat that applies with or without compaction, not a reason to treat it differently). Fixed a latent bug this exposed: `_merge_output` wasn't applying the same `id_field or "fid"` fallback used elsewhere, causing a bare `AssertionError` once compaction could actually reach that path with no real id.

## Testing

- New unit tests for `resolve_default_id_field()`: file input with a real FID column, file input with none (Shapefile, warns and falls back).
- New PostGIS integration tests (testcontainers): single-column PK auto-detected and used; composite PK correctly falls back to synthetic.
- Updated compaction tests: the old "no `-id` + `-co` always raises" assumption no longer holds — repurposed to assert the new success paths (real auto-detected ID, and synthetic-ID fallback), at both the CLI and library-API (`common.index()`) level.
- New `TestOutputValidation` tests: no stray `index` column with or without an explicit `id_field`; default (no `-id`) output uses real FIDs, not a 0-based sequence; `-co` without `-id` succeeds via auto-detection.
- README `--help` block regenerated and kept in sync (enforced by `TestReadmeHelp`).
- Full test suite: 254 passed.

Closes #195
Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)