### PR TITLE
Harden compaction_common / _merge_partition_files against non-string cell ID dtypes

### DIFF
--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -5,6 +5,8 @@ from unittest import TestCase, mock
 
 import geopandas as gpd
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pyogrio
 from shapely.geometry import Point, box
 
@@ -477,3 +479,37 @@ class TestCommitOutput(TestCase):
             result = common._commit_output(staging, target, overwrite=True)
             self.assertEqual([p.name for p in Path(result).iterdir()], ["new.parquet"])
             self.assertFalse(staging.exists())
+
+
+class TestMergePartitionFilesDtypeSafety(TestCase):
+    """
+    _merge_partition_files's schema-unification step normalises string vs
+    large_string mismatches across part files, but left an equivalent gap
+    for numeric cell-id dtype mismatches: pyarrow's own "permissive" schema
+    unification silently picks int64 over uint64 for a mismatched field,
+    which would corrupt a genuine uint64 cell ID above 2**63-1 on cast.
+    Reproduced here with synthetic part files, ahead of any real backend
+    adopting a native int cell-id form.
+    """
+
+    def test_int64_uint64_mismatch_unifies_to_uint64_not_silently_narrowed(self):
+        with tempfile.TemporaryDirectory() as d:
+            partition_dir = Path(d)
+            pq.write_table(
+                pa.table({"cell": pa.array([1, 2, 3], type=pa.uint64())}),
+                partition_dir / "part-0.parquet",
+            )
+            pq.write_table(
+                pa.table({"cell": pa.array([4, 5, 6], type=pa.int64())}),
+                partition_dir / "part-1.parquet",
+            )
+
+            common._merge_partition_files(partition_dir, compression="snappy")
+
+            merged = list(partition_dir.glob("*.parquet"))
+            self.assertEqual(len(merged), 1)
+            table = pq.read_table(merged[0])
+            self.assertEqual(table.schema.field("cell").type, pa.uint64())
+            self.assertEqual(
+                sorted(table.column("cell").to_pylist()), [1, 2, 3, 4, 5, 6]
+            )

--- a/tests/classes/compaction.py
+++ b/tests/classes/compaction.py
@@ -1,6 +1,7 @@
 from itertools import product
 from unittest import TestCase
 
+import numpy as np
 import pandas as pd
 
 from vector2dggs.indexers.vectorindexer import VectorIndexer
@@ -368,3 +369,104 @@ class TestA5CompactionBounds(TestCase):
                 for c in result.index
             )
         )
+
+
+class _SyntheticIndexer(VectorIndexer):
+    """A concrete but otherwise-unused VectorIndexer, so compaction_common
+    (a real, non-abstract instance method) can be called directly with
+    synthetic cell functions - isolating the shared algorithm from any real
+    backend's semantics."""
+
+    def _polyfill_polygons(self, df, resolution):
+        raise NotImplementedError
+
+    def _polyfill_linestrings(self, df, resolution):
+        raise NotImplementedError
+
+    def _polyfill_points(self, df, resolution):
+        raise NotImplementedError
+
+    def secondary_index(self, df, parent_res):
+        raise NotImplementedError
+
+    def compaction(self, df, res, col_order, dggs_col, id_field, parent_res):
+        raise NotImplementedError
+
+    @staticmethod
+    def cell_to_point(cell):
+        raise NotImplementedError
+
+    @staticmethod
+    def cell_to_polygon(cell):
+        raise NotImplementedError
+
+    @staticmethod
+    def get_resolution(cell):
+        raise NotImplementedError
+
+    @staticmethod
+    def children_at_res(cell, target_res):
+        raise NotImplementedError
+
+
+class TestCompactionCommonDtypeSafety(TestCase):
+    """
+    compaction_common builds a fresh pd.Series from a plain Python list of
+    compacted cell IDs (parent_for_pair), separately from the incoming
+    dataframe's own dggs_col. Left to inference, pandas picks int64 or
+    uint64 per list depending on whether any value exceeds 2**63-1,
+    independently of the source column's actual dtype - and concatenating a
+    frame with a mismatched int64/uint64 index silently upcasts the result
+    to float64, corrupting cell IDs. Reproduced here with synthetic
+    (non-string) cell IDs, ahead of any real backend adopting them.
+    """
+
+    DGGS_COL = "synthetic_02"
+
+    def setUp(self):
+        self.indexer = _SyntheticIndexer(dggs="synthetic")
+        # Feature A's three fine cells fully cover parent cell 100 and
+        # compact away entirely; feature B's one cell has no siblings and
+        # stays as-is - so the result concatenates a freshly-built
+        # (compacted) frame with a slice of the original (uncompacted) one.
+        self.df = pd.DataFrame(
+            {
+                "id": ["A", "A", "A", "B"],
+                "attr": [1, 2, 3, 4],
+                self.DGGS_COL: pd.array([1000, 1001, 1002, 2000], dtype="uint64"),
+            }
+        )
+
+    @staticmethod
+    def _compact_func(cells):
+        cells = set(cells)
+        return {100} if cells == {1000, 1001, 1002} else cells
+
+    @staticmethod
+    def _cell_to_child_func(cell, res):
+        return {100: 1000}[cell]
+
+    @staticmethod
+    def _get_resolution_func(cell):
+        return 2 if cell >= 1000 else 1
+
+    @staticmethod
+    def _children_at_res_func(cell, target_res):
+        return {cell}
+
+    def test_compacted_result_preserves_uint64_dtype(self):
+        result = self.indexer.compaction_common(
+            self.df,
+            res=2,
+            id_field="id",
+            col_order=["id", "attr"],
+            dggs_col=self.DGGS_COL,
+            compact_func=self._compact_func,
+            cell_to_child_func=self._cell_to_child_func,
+            parent_res=1,
+            get_resolution_func=self._get_resolution_func,
+            children_at_res_func=self._children_at_res_func,
+        )
+
+        self.assertEqual(result.index.dtype, np.dtype("uint64"))
+        self.assertEqual({int(c) for c in result.index}, {100, 2000})

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -31,6 +31,10 @@ with contextlib.suppress(ImportError):
     from .classes.compaction import TestA5CompactionBounds as TestA5CompactionBounds
 with contextlib.suppress(ImportError):
     from .classes.compaction import (
+        TestCompactionCommonDtypeSafety as TestCompactionCommonDtypeSafety,
+    )
+with contextlib.suppress(ImportError):
+    from .classes.compaction import (
         TestGeohashCompactionBounds as TestGeohashCompactionBounds,
     )
 with contextlib.suppress(ImportError):
@@ -68,6 +72,10 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.common_units import (
         TestReadBatchesColumnSelection as TestReadBatchesColumnSelection,
+    )
+with contextlib.suppress(ImportError):
+    from .classes.common_units import (
+        TestMergePartitionFilesDtypeSafety as TestMergePartitionFilesDtypeSafety,
     )
 with contextlib.suppress(ImportError):
     from .classes.common_units import (

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -459,18 +459,29 @@ def _merge_partition_files(
                 all_bboxes.append(col["bbox"])
             all_geometry_types.update(col.get("geometry_types", []))
 
-    # Build a unified schema: for each field, prefer large_string over string so
-    # that all partitions (which may have written either variant) can be cast cleanly.
+    # Build a unified schema: for each field, prefer the wider/safer variant so
+    # that all partitions (which may disagree) can be cast cleanly without
+    # loss - large_string over string, and uint64 over int64 (a non-negative
+    # int64 value always fits losslessly in uint64, not vice versa; pyarrow's
+    # own "permissive" unification silently picks int64 for this exact
+    # mismatch, which would corrupt a genuine uint64 cell ID above 2**63-1).
+    per_field_types: dict[str, set[pa.DataType]] = {}
+    for t in tables:
+        for field in t.schema:
+            per_field_types.setdefault(field.name, set()).add(field.type)
+
     unified_schema = tables[0].schema
     for t in tables[1:]:
         unified_schema = pa.unify_schemas(
             [unified_schema, t.schema], promote_options="permissive"
         )
-    # Normalise string / large_string mismatches to large_string
     unified_fields = []
     for field in unified_schema:
+        seen = per_field_types.get(field.name, set())
         if pa.types.is_string(field.type):
             unified_fields.append(field.with_type(pa.large_utf8()))
+        elif {pa.int64(), pa.uint64()} <= seen:
+            unified_fields.append(field.with_type(pa.uint64()))
         else:
             unified_fields.append(field)
     unified_schema = pa.schema(unified_fields, metadata=unified_schema.metadata)

--- a/vector2dggs/indexers/vectorindexer.py
+++ b/vector2dggs/indexers/vectorindexer.py
@@ -142,6 +142,14 @@ class VectorIndexer(ABC):
         a cell coarser than parent_res.
         """
         df = df.reset_index(drop=False)
+        # Captured before any construction below, so a fresh pd.Series built
+        # from a plain Python list of cell IDs (e.g. parent_for_pair below)
+        # can be pinned to it explicitly. Left to inference, pandas picks
+        # int64 or uint64 per list based on whether any value exceeds
+        # 2**63-1 - inconsistently with the source column, whose dtype this
+        # sidesteps entirely - and concatenating mismatched int64/uint64
+        # frames silently upcasts the result to float64, corrupting cell IDs.
+        cell_dtype = df[dggs_col].dtype
 
         if df.empty:
             # e.g. an empty partition after a shuffle; the mask logic below
@@ -190,6 +198,7 @@ class VectorIndexer(ABC):
             parent_for_pair = pd.Series(
                 list(compression_mapping.values()),
                 index=pd.MultiIndex.from_tuples(list(compression_mapping.keys())),
+                dtype=cell_dtype,
             )
             sel = pairs.isin(parent_for_pair.index)
             compressable_df = (


### PR DESCRIPTION
Prerequisite groundwork for native uint64 cell IDs (#198, #199, #200), mirroring a change already shipped in raster2dggs — manaakiwhenua/raster2dggs#96, implemented in manaakiwhenua/raster2dggs#97. **No user-visible behaviour change**: today every cell ID in vector2dggs is a string, so this hazard can't currently fire. This closes the gap before any backend actually emits a non-string one, with synthetic (non-backend-specific) test data proving it, same order raster2dggs's own PR did it in.

## The hazard

pandas silently promotes `uint64` to `float64` whenever it meets an `int64` or float value in the same operation — no error, no warning. float64 has ~128-step spacing at H3-cell magnitude, so this doesn't round to "close enough", it corrupts the value into a different, usually invalid, cell. raster2dggs hit this exact failure class in their own structurally-equivalent compaction code and had to fix it (their `rasterindexer.py`, PR #97):

```python
if pd.api.types.is_unsigned_integer_dtype(df.index.dtype):
    # A Python-int label re-infers a one-row index as int64, and int64
    # concatenated with uint64 promotes to float64, rounding cell IDs.
    parent = np.uint64(parent)
```

## What's fixed here

**`VectorIndexer.compaction_common()`** built `parent_for_pair` via `pd.Series(list(compression_mapping.values()), ...)` with no explicit `dtype=`, letting pandas infer `int64` or `uint64` per list independently of the source column's actual dtype. Concatenating that against the correctly-typed `uncompressable_df` then silently upcasts both to `float64` whenever the two disagree — and this isn't an edge case, **any compaction run with at least one compressible cell and one uncompressible cell hits it**. Fixed by pinning the construction to the source column's own dtype (`cell_dtype = df[dggs_col].dtype`, captured once up front).

**`_merge_partition_files()`**'s schema-unification step only reconciled `string`/`large_string` mismatches across part files. PyArrow's own `unify_schemas(..., promote_options="permissive")` silently prefers `int64` over `uint64` for a mismatched field — verified directly — which would corrupt a genuine uint64 cell ID above `2**63-1` on cast, and even for smaller values, silently hands downstream consumers (e.g. DuckDB expecting `uint64`) the wrong dtype. Fixed by extending the function's own existing prefer-the-safe-wider-variant pattern (already used for `string` → `large_string`) to also cover `int64`/`uint64`.

## Testing

Both fixes are proven by first confirming the test fails without the fix (reverted locally, confirmed the exact predicted corruption — `float64` instead of `uint64`, and a silent `int64` instead of `uint64` — then reapplied and confirmed green):

- `TestCompactionCommonDtypeSafety` (`tests/classes/compaction.py`): a minimal synthetic `VectorIndexer` subclass with hand-written compact/child/resolution functions operating on plain `int` cell IDs, proving a compacted result concatenating a freshly-built (compressed) frame with a slice of the original (uncompressed) one preserves `uint64` dtype exactly.
- `TestMergePartitionFilesDtypeSafety` (`tests/classes/common_units.py`): two synthetic part files with deliberately mismatched `uint64`/`int64` cell-id columns, proving the merge unifies to `uint64`, not silently narrowed to `int64`.
- No existing test (compaction, output validation, full runthrough) regressed — full suite: 256 passed.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)