### PR TITLE
Native uint64 cell IDs for H3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ vector2dggs <dggs> [OPTIONS] VECTOR_INPUT OUTPUT_DIRECTORY
 - `-id`/`--id_field`: the feature identifier carried into the output. Defaults to the input's own internal ID where one exists (a GPKG's FID column, or a DB table's single-column primary key); otherwise falls back to a synthetic index tied to row position in the read order — stable across repeated runs of the same unchanged input, but not portable to a different export/copy of the same data. Rows sharing an id are treated as one feature.
 - `-co`/`--compact`: merges complete sets of sibling cells belonging to one feature (grouped by whichever id_field is in play, explicit, auto-detected, or synthetic), to no coarser than the parent resolution. Compacted output expands back to exactly the full-resolution result.
 - `--geo`: plain Parquet by default; `point` or `polygon` writes GeoParquet (v1.1.0) cell geometries instead.
-- `--cell-id`: `string` (default) or `uint64`. DGGS with a native integer cell form (A5 currently; H3 and S2 to follow) can write cell IDs as unsigned 64-bit integers instead of text — useful where downstream tools take integer cell IDs directly (e.g. DuckDB's `h3` extension). Cell IDs are worked in the native form internally regardless of this flag; it only controls the final output rendering. String-only DGGS (rHEALPix, Geohash) reject `--cell-id uint64`.
+- `--cell-id`: `string` (default) or `uint64`. DGGS with a native integer cell form (A5, H3 currently; S2 to follow) can write cell IDs as unsigned 64-bit integers instead of text — useful where downstream tools take integer cell IDs directly (e.g. DuckDB's `h3` extension). Cell IDs are worked in the native form internally regardless of this flag; it only controls the final output rendering. String-only DGGS (rHEALPix, Geohash) reject `--cell-id uint64`.
 
 The full reference (`vector2dggs h3 --help`; the other commands differ only in their resolution ranges):
 
@@ -120,9 +120,9 @@ Options:
                                   metadata), or 'point'/'polygon' to write
                                   GeoParquet (v1.1.0) with the corresponding
                                   geometry type.  [default: none]
-  --cell-id [string]              Cell ID output form. H3 cell IDs are strings
-                                  with no integer form, so only 'string' is
-                                  available.  [default: string]
+  --cell-id [string|uint64]       Cell ID output form: 'string' (default) or
+                                  'uint64' (unsigned 64-bit integer; e.g. for
+                                  DuckDB interop).  [default: string]
   --tempdir PATH                  Temporary data is created during the execution
                                   of this program. This parameter allows you to
                                   control where this data will be written.

--- a/tests/classes/cell_id_mode.py
+++ b/tests/classes/cell_id_mode.py
@@ -2,6 +2,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from vector2dggs.a5 import a5
+from vector2dggs.h3 import h3
 
 from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME
 from .base import TestRunthrough, skip_unless_backend
@@ -84,3 +85,67 @@ class TestA5CellIdUint64(TestRunthrough):
         for token in list(tokens)[:20]:
             # raises if not a valid a5 hex token
             a5py.hex_to_u64(token)
+
+
+class TestH3CellIdUint64(TestRunthrough):
+    """
+    End-to-end regression for issue #199, mirroring TestA5CellIdUint64
+    (see its docstring for the dtype-safety rationale).
+    """
+
+    DGGS_COL = "h3_09"
+
+    @classmethod
+    def setUpClass(cls):
+        skip_unless_backend("h3")
+        super().setUpClass()
+
+    def _run(self, extra=()):
+        h3(
+            [
+                TEST_FILE_PATH,
+                str(self.output_path),
+                "--layer",
+                TEST_LAYER_NAME,
+                "-r",
+                "9",
+                "-id",
+                "LCDB_UID",
+                "-t",
+                "1",
+                *extra,
+            ],
+            standalone_mode=False,
+        )
+
+    def _dggs_col_type(self):
+        files = sorted(self.output_path.rglob("*.parquet"))
+        self.assertTrue(files, "no parquet output written")
+        table = pq.read_table(files[0])
+        self.assertIn(self.DGGS_COL, table.schema.names)
+        return table, table.schema.field(self.DGGS_COL).type
+
+    def test_uint64_output_no_compaction(self):
+        self._run(("--cell-id", "uint64"))
+        _, field_type = self._dggs_col_type()
+        self.assertEqual(field_type, pa.uint64())
+
+    def test_uint64_output_with_compaction_and_scattered_partitions(self):
+        self._run(("--cell-id", "uint64", "-co", "-c", "50000"))
+        _, field_type = self._dggs_col_type()
+        self.assertEqual(field_type, pa.uint64())
+
+    def test_string_output_unaffected(self):
+        """Default (string) output is unchanged by #199: still a string
+        column, values still valid h3 tokens - not a behaviour change for
+        existing users."""
+        import h3 as h3py
+
+        self._run(())
+        table, field_type = self._dggs_col_type()
+        self.assertIn(field_type, (pa.string(), pa.large_utf8()))
+        df = table.to_pandas()
+        tokens = df[self.DGGS_COL] if self.DGGS_COL in df.columns else df.index
+        for token in list(tokens)[:20]:
+            # raises if not a valid h3 string token
+            h3py.str_to_int(token)

--- a/tests/classes/common_units.py
+++ b/tests/classes/common_units.py
@@ -355,7 +355,9 @@ class TestWritePartitionGuards(TestCase):
         # input (the caller, _polyfill(), computes what it needs from the
         # original before calling this). Locking in the "may mutate"
         # contract here so a defensive copy doesn't silently creep back in.
-        df = pd.DataFrame({"c": ["a", "b"], "p": [1, 2]})
+        # H3 is int-native (#199): placeholder ints, not real cells - this
+        # only checks the generic mutation contract, not H3 correctness.
+        df = pd.DataFrame({"c": [10, 20], "p": [1, 2]})
         with tempfile.TemporaryDirectory() as d:
             common.write_partition(
                 df, None, Path(d), "p", "c", "snappy", self.INDEXER, "string", False

--- a/tests/classes/compaction.py
+++ b/tests/classes/compaction.py
@@ -10,6 +10,7 @@ from .base import skip_unless_backend
 
 try:
     import h3
+    from h3.api import basic_int as h3int
 
     from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer
 except ImportError:
@@ -43,6 +44,10 @@ class TestH3CompactionBounds(TestCase):
     Compaction must never produce cells coarser (lower resolution) than
     parent_res, even when a feature's cells fully cover an ancestor that is
     coarser than parent_res.
+
+    H3 works natively in int throughout (issue #199); its string token
+    form is now purely an output-boundary rendering (cells_to_string), not
+    something get_resolution/children_at_res/compaction accept as input.
     """
 
     def setUp(self):
@@ -50,26 +55,29 @@ class TestH3CompactionBounds(TestCase):
         self.parent_res = 5
         # An ancestor one level coarser than parent_res, fully covered by all
         # of its grandchildren at parent_res + 1.
-        self.ancestor = h3.latlng_to_cell(-41.0, 174.0, self.parent_res - 1)
+        self.ancestor = h3int.latlng_to_cell(-41.0, 174.0, self.parent_res - 1)
         self.res = self.parent_res + 1
-        self.cells = set(h3.cell_to_children(self.ancestor, self.res))
+        self.cells = set(h3int.cell_to_children(self.ancestor, self.res))
 
     def test_unbounded_compaction_would_exceed_parent_res(self):
         # Demonstrates the underlying behaviour that necessitates the floor:
         # h3.compact_cells has no resolution floor and will compact past
         # parent_res whenever the cells fully cover a coarser ancestor.
-        unbounded = set(h3.compact_cells(self.cells))
+        unbounded = set(h3int.compact_cells(self.cells))
         self.assertEqual(unbounded, {self.ancestor})
-        self.assertLess(h3.get_resolution(self.ancestor), self.parent_res)
+        self.assertLess(h3int.get_resolution(self.ancestor), self.parent_res)
 
     def test_enforce_resolution_floor_breaks_up_coarse_cells(self):
         result = VectorIndexer._enforce_resolution_floor(
-            {self.ancestor}, self.parent_res, h3.get_resolution, h3.cell_to_children
+            {self.ancestor},
+            self.parent_res,
+            h3int.get_resolution,
+            h3int.cell_to_children,
         )
 
-        self.assertTrue(all(h3.get_resolution(c) >= self.parent_res for c in result))
+        self.assertTrue(all(h3int.get_resolution(c) >= self.parent_res for c in result))
         self.assertEqual(
-            result, set(h3.cell_to_children(self.ancestor, self.parent_res))
+            result, set(h3int.cell_to_children(self.ancestor, self.parent_res))
         )
 
     def test_compaction_respects_parent_res(self):
@@ -79,7 +87,7 @@ class TestH3CompactionBounds(TestCase):
             {
                 "id": [1] * len(self.cells),
                 "attr": range(len(self.cells)),
-                dggs_col: list(self.cells),
+                dggs_col: pd.array(list(self.cells), dtype="uint64"),
             }
         )
 
@@ -88,8 +96,16 @@ class TestH3CompactionBounds(TestCase):
         )
 
         self.assertTrue(
-            all(h3.get_resolution(c) >= self.parent_res for c in result.index)
+            all(h3int.get_resolution(c) >= self.parent_res for c in result.index)
         )
+        self.assertEqual(result.index.dtype, np.dtype("uint64"))
+
+    def test_cells_to_string_round_trips_exactly(self):
+        indexer = H3VectorIndexer(dggs="h3")
+        strings = indexer.cells_to_string(self.cells)
+        self.assertEqual(len(set(strings)), len(self.cells))
+        self.assertTrue(all(isinstance(s, str) for s in strings))
+        self.assertEqual({h3.str_to_int(s) for s in strings}, self.cells)
 
 
 class TestGeohashCompactionBounds(TestCase):

--- a/tests/classes/errors.py
+++ b/tests/classes/errors.py
@@ -12,9 +12,10 @@ from shapely.geometry import Polygon
 from vector2dggs import common
 from vector2dggs.h3 import h3
 from vector2dggs.indexerfactory import indexer_instance
+from vector2dggs.rHP import rhp
 
 from ..data.datapaths import TEST_FILE_PATH, TEST_LAYER_NAME
-from .base import TestRunthrough
+from .base import TestRunthrough, skip_unless_backend
 
 
 class TestErrors(TestRunthrough):
@@ -151,11 +152,12 @@ class TestErrors(TestRunthrough):
             )
 
     def test_cell_id_uint64_rejected_for_string_only_backend(self):
-        """H3 has no --cell-id uint64 support until #199: rejected by the
-        CLI's own dynamically-restricted --cell-id choices, before any of
-        our own validation runs."""
+        """rHEALPix has no integer cell form (unlike H3/S2/A5): rejected by
+        the CLI's own dynamically-restricted --cell-id choices, before any
+        of our own validation runs."""
+        skip_unless_backend("rhp")
         with self.assertRaises(click.BadParameter):
-            h3(
+            rhp(
                 [
                     TEST_FILE_PATH,
                     str(self.output_path),
@@ -172,7 +174,8 @@ class TestErrors(TestRunthrough):
     def test_check_cell_id_rejects_string_only_backend(self):
         """The library-API guard (common.check_cell_id), independent of the
         CLI's own Click-level restriction."""
-        indexer = indexer_instance("h3")
+        skip_unless_backend("rhp")
+        indexer = indexer_instance("rhp")
         with self.assertRaises(common.CellIdError):
             common.check_cell_id("uint64", indexer)
 

--- a/tests/classes/write_limits.py
+++ b/tests/classes/write_limits.py
@@ -2,8 +2,8 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase, mock, skipIf
 
-import h3 as h3lib
 import pandas as pd
+from h3.api import basic_int as h3lib
 
 from vector2dggs import common
 from vector2dggs.indexers.h3vectorindexer import H3VectorIndexer

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -30,6 +30,8 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.cell_id_mode import TestA5CellIdUint64 as TestA5CellIdUint64
 with contextlib.suppress(ImportError):
+    from .classes.cell_id_mode import TestH3CellIdUint64 as TestH3CellIdUint64
+with contextlib.suppress(ImportError):
     from .classes.compaction import TestA5CompactionBounds as TestA5CompactionBounds
 with contextlib.suppress(ImportError):
     from .classes.compaction import (

--- a/vector2dggs/h3.py
+++ b/vector2dggs/h3.py
@@ -1,4 +1,4 @@
 import vector2dggs.constants as const
 from vector2dggs.cli_factory import make_dggs_command
 
-h3 = make_dggs_command("h3", "h3", "H3", const.MIN_H3, const.MAX_H3)
+h3 = make_dggs_command("h3", "h3", "H3", const.MIN_H3, const.MAX_H3, int_cells=True)

--- a/vector2dggs/indexers/h3vectorindexer.py
+++ b/vector2dggs/indexers/h3vectorindexer.py
@@ -1,30 +1,54 @@
+from collections.abc import Iterable
+
 import geopandas as gpd
 import h3
 import pandas as pd
+import pyarrow as pa
+from h3.api import basic_int
 from shapely.geometry import Point, Polygon, mapping
 
 from vector2dggs.indexers.vectorindexer import VectorIndexer
 
 
-class H3VectorIndexer(VectorIndexer[str]):
+def _as_int(cell: str | int) -> int:
+    """
+    Accepts either form: the working native int (from within the
+    pipeline), or the h3 string token (e.g. reading a --cell-id string
+    output file back and using these methods as a standalone convenience,
+    the way tests do against the pipeline's own default output).
+    """
+    return h3.str_to_int(cell) if isinstance(cell, str) else int(cell)
+
+
+class H3VectorIndexer(VectorIndexer[str | int]):
     """
     Provides integration for Uber's H3 DGGS.
+
+    h3-py cells are natively int (h3.api.basic_int); the string token form
+    is produced only at the output boundary via cells_to_string.
     """
 
     GEODESIC_POLYFILL = True
+    CELL_ARROW_TYPE: pa.DataType = pa.uint64()
+
+    @staticmethod
+    def cells_to_string(cells: Iterable[str | int]) -> list[str]:
+        return [h3.int_to_str(int(c)) for c in cells]
 
     @staticmethod
     def _polyfill_polygon(geom, resolution: int) -> list:
-        return h3.geo_to_cells(mapping(geom), resolution)
+        return basic_int.geo_to_cells(mapping(geom), resolution)
 
     @staticmethod
     def _linetrace(geom, resolution: int) -> list:
         coords = list(geom.coords)
         cells = set()
         for i in range(len(coords) - 1):
-            start = h3.latlng_to_cell(coords[i][1], coords[i][0], resolution)
-            end = h3.latlng_to_cell(coords[i + 1][1], coords[i + 1][0], resolution)
-            cells.update(h3.grid_path_cells(start, end))
+            start = basic_int.latlng_to_cell(coords[i][1], coords[i][0], resolution)
+            end = basic_int.latlng_to_cell(
+                coords[i + 1][1], coords[i + 1][0], resolution
+            )
+            cells.update(basic_int.grid_path_cells(start, end))
         return list(cells)
 
     def _polyfill_polygons(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
@@ -41,52 +65,61 @@ class H3VectorIndexer(VectorIndexer[str]):
         return self._geo_to_cells(
             df,
             resolution,
-            lambda geom, res: [h3.latlng_to_cell(geom.y, geom.x, res)],
+            lambda geom, res: [basic_int.latlng_to_cell(geom.y, geom.x, res)],
             df.geometry.name,
         )
 
     def secondary_index(self, df: pd.DataFrame, parent_res: int) -> pd.DataFrame:
         df[f"h3_{parent_res:02}"] = df.index.map(
-            lambda cell: h3.cell_to_parent(cell, parent_res)
-        )
+            lambda cell: basic_int.cell_to_parent(int(cell), parent_res)
+        ).astype("uint64")
         return df
 
     def compaction(self, df, res, col_order, dggs_col, id_field, parent_res):
+        def _compact(cells):
+            return basic_int.compact_cells([int(c) for c in cells])
+
+        def _child(cell, res):
+            return basic_int.cell_to_center_child(int(cell), res)
+
         return self.compaction_common(
             df,
             res,
             id_field,
             col_order,
             dggs_col,
-            h3.compact_cells,
-            h3.cell_to_center_child,
+            _compact,
+            _child,
             parent_res,
             self.get_resolution,
             self.children_at_res,
         )
 
     @staticmethod
-    def get_resolution(cell: str) -> int:
+    def get_resolution(cell: str | int) -> int:
         """
-        Returns the resolution of a cell.
+        Returns the resolution of a cell (native int, or string token).
 
         Not a part of the interface provided by VectorIndexer.
         """
-        return h3.get_resolution(cell)
+        return basic_int.get_resolution(_as_int(cell))
 
     @staticmethod
-    def children_at_res(cell: str, target_res: int) -> list[str]:
+    def children_at_res(cell: str | int, target_res: int) -> list[int]:
         """
-        Return all descendants of cell at resolution target_res.
+        Return all descendants of cell (native int, or string token) at
+        resolution target_res.
 
         Not a part of the interface provided by VectorIndexer.
         """
-        return h3.cell_to_children(cell, target_res)
+        return basic_int.cell_to_children(_as_int(cell), target_res)
 
     @staticmethod
-    def cell_to_point(cell: str) -> Point:
-        return Point(h3.cell_to_latlng(cell)[::-1])
+    def cell_to_point(cell: str | int) -> Point:
+        return Point(basic_int.cell_to_latlng(_as_int(cell))[::-1])
 
     @staticmethod
-    def cell_to_polygon(cell: str) -> Polygon:
-        return Polygon(tuple(coord[::-1] for coord in h3.cell_to_boundary(cell)))
+    def cell_to_polygon(cell: str | int) -> Polygon:
+        return Polygon(
+            tuple(coord[::-1] for coord in basic_int.cell_to_boundary(_as_int(cell)))
+        )


### PR DESCRIPTION
Reuses #198's shared \`--cell-id\` infrastructure and "always native internally, string only at the output boundary" architecture. This was the smallest-diff backend change of the three capable ones — near-mechanical, following A5's already-established pattern from #198.

## What changed

- \`h3-py\` ships \`h3.api.basic_int\`, a complete drop-in mirror of the default string \`h3\` module but returning/accepting native Python \`int\` throughout. Every module-level \`h3.*\` call in \`H3VectorIndexer\` (polyfill, linetrace, \`secondary_index\`, compaction, \`get_resolution\`, \`children_at_res\`, \`cell_to_point\`/\`cell_to_polygon\`) swaps to \`basic_int.*\`.
- \`CELL_ARROW_TYPE = pa.uint64()\`, \`cells_to_string()\` (via \`h3.int_to_str\`) for the output-boundary render — same shape as A5's implementation.
- A dual-mode \`_as_int()\` helper (native int, or a string token via \`h3.str_to_int\`, auto-detected) so the four cell-accepting utility methods work whether called from within the pipeline (always native) or as a standalone convenience against a \`--cell-id string\` output file — the same reason A5 needed this, exercised the same way by the shared \`runthrough\` test helper (which reads the final written output back and calls \`get_resolution\`/\`cell_to_point\` on it directly).
- \`vector2dggs/h3.py\`: \`int_cells=True\`, enabling \`--cell-id uint64\` on the CLI.

## Test fixes required (not new bugs — #198's tests used H3 as a placeholder)

- Two of #198's own tests used H3 as the "string-only backend" rejection example (\`--cell-id uint64\` should fail) — now capable, so switched to rHEALPix (still string-only).
- Two generic \`write_partition\` tests (\`write_limits.py\`, \`common_units.py\`) used \`H3VectorIndexer\` as a representative indexer with string-shaped placeholder cell values — updated to native-int placeholders matching H3's new working form (these were never testing H3-specific correctness, just generic write-path behaviour).
- \`TestH3CompactionBounds\` updated to the native-int contract, following A5's precedent from #198.

## Testing

- New \`TestH3CellIdUint64\` (mirrors \`TestA5CellIdUint64\`): the highest-risk combination (multi-file-per-partition merge + compaction) asserts the Parquet cell-id column's Arrow dtype is exactly \`uint64\`, never \`float64\`/\`int64\`; default (\`string\`) output verified unaffected — real h3 tokens, unchanged column type.
- \`polyfill_contract.py\`'s mode-aware contract (already generic since #198, derives expected type from \`indexer.CELL_ARROW_TYPE\`) needed no changes and now correctly covers H3 as int-native.
- README \`--help\` block resynced (H3 is the project's reference backend for that test).
- Full test suite: 267 passed. \`mypy vector2dggs/\` (whole-package, matching CI) clean.

S2 (#200) remains, reusing the same shared infrastructure.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)