### PR TITLE
-p/--processes as primary spelling of the parallelism option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ Options:
                                   cutting CRS. A threshold of 0 will skip
                                   bisection entirely (effectively ignoring
                                   --cut_crs).
-  -t, --threads INTEGER RANGE     Amount of threads used for operation
-                                  [default: (CPU count - 1, capped by available
-                                  memory); x>=1]
+  -p, -t, --processes, --threads INTEGER RANGE
+                                  Number of parallel workers: process pools for
+                                  indexing and for merging/compaction, and the
+                                  thread pool for bisection.  [default: (CPU
+                                  count - 1, capped by available memory); x>=1]
   -cp, --compression TEXT         Compression method to use for the output
                                   Parquet files. Options include 'snappy',
                                   'gzip', 'brotli', 'lz4', 'zstd', etc. Use

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -83,13 +83,16 @@ def make_dggs_command(
         nargs=1,
     )
     @click.option(
+        "-p",
+        "--processes",
         "-t",
         "--threads",
+        "processes",
         required=False,
         default=const.DEFAULTS["t"],
         show_default="CPU count - 1, capped by available memory",
         type=click.IntRange(min=1),
-        help="Amount of threads used for operation",
+        help="Number of parallel workers: process pools for indexing and for merging/compaction, and the thread pool for bisection.",
         nargs=1,
     )
     @click.option(
@@ -169,7 +172,7 @@ def make_dggs_command(
         keep_attribute: tuple[str, ...],
         cut_crs: int,
         cut_threshold: float,
-        threads: int,
+        processes: int,
         compression: str,
         layer: str,
         geom_col: str,
@@ -204,7 +207,7 @@ def make_dggs_command(
             parent_res,
             keep_attributes,
             cut_threshold,
-            threads,
+            processes,
             compression=compression,
             cut_crs=cut_crs_obj,
             id_field=id_field,


### PR DESCRIPTION
Fixes #207.

`-t/--threads` is the pipeline's single parallelism dial, but two of the three pools it controls are process pools (indexing; merging/compaction) — only bisection uses threads. One option now carries four spellings, `-p, -t, --processes, --threads`, binding to the same value; `--processes` is the documented primary name and the help text states exactly which pools it governs. No behaviour change; existing `-t` usage is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)