### PR TITLE
Announce default-layer choice on multi-layer inputs

### DIFF
--- a/tests/classes/ingest.py
+++ b/tests/classes/ingest.py
@@ -1,7 +1,10 @@
 import tempfile
+import warnings
 from unittest import TestCase, mock
 
+import geopandas as gpd
 import pandas as pd
+from shapely.geometry import Point
 
 import vector2dggs.constants as const
 from vector2dggs import common
@@ -43,3 +46,52 @@ class TestBatchedIngest(TestCase):
         self.assertEqual(
             sorted(single["fid"].unique()), sorted(batched["fid"].unique())
         )
+
+
+class TestDefaultLayer(TestCase):
+    """A multi-layer input indexed without --layer must announce which layer
+    it chose in the tool's own log voice, once, instead of leaving it to
+    pyogrio's easily-missed UserWarning; single-layer inputs stay quiet."""
+
+    def _write_multi(self, path):
+        first = gpd.GeoDataFrame({"geometry": [Point(174.0, -41.0)]}, crs=4326)
+        second = gpd.GeoDataFrame(
+            {"geometry": [Point(10.0, 10.0), Point(11.0, 11.0)]}, crs=4326
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            first.to_file(path, layer="zebra")
+            second.to_file(path, layer="alpha")
+
+    def _index(self, src, out):
+        return common.index("h3", src, out, 5, None, False, 1, compact=False)
+
+    def test_multi_layer_default_is_announced_and_first_layer_indexed(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_multi(f"{d}/multi.gpkg")
+            with self.assertLogs(common.LOGGER, level="WARNING") as logs:
+                self._index(f"{d}/multi.gpkg", f"{d}/out.pq")
+            message = "\n".join(logs.output)
+            self.assertIn("zebra", message)
+            self.assertIn("alpha", message)
+            self.assertIn("--layer", message)
+            # the default (first) layer, and only it, was indexed
+            out = pd.read_parquet(f"{d}/out.pq")
+            self.assertEqual(out["fid"].nunique(), 1)
+
+    def test_pyogrio_multi_layer_warning_is_superseded(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_multi(f"{d}/multi.gpkg")
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                self._index(f"{d}/multi.gpkg", f"{d}/out.pq")
+        self.assertFalse([w for w in caught if "More than one layer" in str(w.message)])
+
+    def test_single_layer_stays_quiet(self):
+        with tempfile.TemporaryDirectory() as d:
+            df = gpd.GeoDataFrame({"geometry": [Point(174.0, -41.0)]}, crs=4326)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                df.to_file(f"{d}/single.gpkg", layer="only")
+            with self.assertNoLogs(common.LOGGER, level="WARNING"):
+                self._index(f"{d}/single.gpkg", f"{d}/out.pq")

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -119,6 +119,7 @@ with contextlib.suppress(ImportError):
     from .classes.errors import TestStagedOutput as TestStagedOutput
 with contextlib.suppress(ImportError):
     from .classes.ingest import TestBatchedIngest as TestBatchedIngest
+    from .classes.ingest import TestDefaultLayer as TestDefaultLayer
 with contextlib.suppress(ImportError):
     from .classes.input_dispatch import TestInputDispatch as TestInputDispatch
 with contextlib.suppress(ImportError):

--- a/vector2dggs/cli_factory.py
+++ b/vector2dggs/cli_factory.py
@@ -153,7 +153,7 @@ def make_dggs_command(
         keep_attribute: tuple[str, ...],
         processes: int,
         compression: str,
-        layer: str,
+        layer: str | None,
         geom_col: str,
         geo: str,
         cell_id: str,
@@ -170,6 +170,7 @@ def make_dggs_command(
         cell_id = const.CellIdMode(cell_id).value
 
         con, vector_input = common.db_conn_and_input_path(vector_input)
+        layer = common.resolve_layer(vector_input, layer, con)
         output_directory = common.resolve_output_path(output_directory, overwrite)
         common.check_requested_attributes(keep_attribute, vector_input, layer, con)
         common.check_id_field(id_field, vector_input, layer, con)

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -141,6 +141,32 @@ def check_id_field(
         )
 
 
+def resolve_layer(
+    input_file: Path | str,
+    layer: str | None,
+    con: SQLConnectionType | None = None,
+) -> str | None:
+    """
+    When no layer is requested and the input has several, GDAL would silently
+    index the first; announce that choice in the tool's own voice and pin the
+    layer explicitly so pyogrio's per-call UserWarning never fires.
+    """
+    if layer is not None or con is not None:
+        return layer
+    layers = pyogrio.list_layers(str(input_file))
+    if len(layers) > 1:
+        names = [name for name, _ in layers]
+        LOGGER.warning(
+            "Input has %d layers: %s. Indexing '%s' (the default). "
+            "Pass -l/--layer to choose a different layer.",
+            len(names),
+            ", ".join(f"'{name}'" for name in names),
+            names[0],
+        )
+        return names[0]
+    return layer
+
+
 def resolve_default_id_field(
     input_file: Path | str,
     layer: str | None,
@@ -1262,6 +1288,7 @@ def index(
     success, so a failed run never destroys previous output (with overwrite)
     nor leaves a half-written target behind.
     """
+    layer = resolve_layer(input_file, layer, con)
     output_directory = resolve_output_path(output_directory, overwrite)
     staging = output_directory.parent / f".{output_directory.name}.staging"
     if staging.exists():


### PR DESCRIPTION
Fixes #211.

When `--layer` is absent and the input has more than one layer, a new `resolve_layer` step logs the choice in the tool's own voice:

```
Input has 2 layers: 'zebra', 'alpha'. Indexing 'zebra' (the default). Pass -l/--layer to choose a different layer.
```

and pins that layer explicitly for the rest of the run, so pyogrio's per-call `UserWarning` (raw stderr, easy to miss among progress bars, fired from an internal metadata call) never appears. The resolution happens before the attribute/id-field checks in the CLI — previously those were the first calls to trip the pyogrio warning — and also inside `common.index()` for library callers. Explicit `--layer` runs, single-layer inputs, and database inputs are untouched.

Tests cover the announcement (and that only the first layer is indexed), the suppression of the pyogrio warning, and single-layer runs staying quiet. Also corrects the click callback's `layer` annotation (`str` → `str | None`; its default is `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
