### PR TITLE
No geographic-CRS warning from the linestring length check

### DIFF
--- a/tests/classes/bisection.py
+++ b/tests/classes/bisection.py
@@ -293,6 +293,16 @@ class TestLinestringBisection(TestCase):
             rebuilt.extend(list(p.coords)[1:])
         self.assertEqual(rebuilt, list(line.coords))
 
+    def test_no_geographic_crs_length_warning(self):
+        import warnings as _warnings
+
+        df = gpd.GeoDataFrame({"geometry": [self._long_line()]}, crs=4326)
+        df.index.name = "fid"
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            _run_bisection(df.copy(), 1e12, 1, line_budget=1.0)
+        self.assertFalse([w for w in caught if "geographic CRS" in str(w.message)])
+
     def test_split_output_cells_identical(self):
         from .base import skip_unless_backend
 

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -1001,7 +1001,9 @@ def _run_bisection(
 
         if line_budget is not None and line_budget > 0:
             line_mask = geom_type.isin(("LineString", "MultiLineString")).to_numpy()
-            lengths = df.geometry.length.to_numpy()
+            # planar CRS-unit length, same units as line_budget; shapely
+            # directly, as GeoSeries.length warns on geographic CRSs
+            lengths = shapely.length(df.geometry.values)
             for pos in np.flatnonzero(line_mask & (lengths > line_budget)):
                 g = df.geometry.iloc[pos]
                 parts = g.geoms if g.geom_type == "MultiLineString" else [g]


### PR DESCRIPTION
Fixes #213.

The linestring-splitting check computed lengths via `GeoSeries.length`, which emits a "Geometry is in a geographic CRS, results likely incorrect" `UserWarning` on every degree-CRS run. The warning doesn't apply: planar CRS-unit length is the intended quantity — the piece budget it's compared against is derived in the same units, and it matches the planar arithmetic of the vertex-splitting walk itself.

Now computed with `shapely.length` on the geometry array, which returns identical values (geopandas delegates to it) without the CRS-aware warning layer. Test asserts no geographic-CRS warning escapes a degree-CRS run. Suite warning count drops from 14 to 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
