### PR TITLE
rHP: drop rhppandas, adopt rhealpixdggs 0.8.3 array APIs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1997,15 +1997,15 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "rhealpixdggs"
-version = "0.8.2"
+version = "0.8.3"
 description = "An implementation of the rHEALPix discrete global grid system"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
 markers = "extra == \"rhp\" or extra == \"all\""
 files = [
-    {file = "rhealpixdggs-0.8.2-py3-none-any.whl", hash = "sha256:76413b64c2c009012289b70f235e08ced326578d602449a8629d3e15cab61c60"},
-    {file = "rhealpixdggs-0.8.2.tar.gz", hash = "sha256:0212643925935620a709f45d5c692d3d917ad8d0759d42a084466c3069328936"},
+    {file = "rhealpixdggs-0.8.3-py3-none-any.whl", hash = "sha256:539a5881fa7c578e38b8a710858eb71bd7a0771f7fd7ec7123aff7624a70f45f"},
+    {file = "rhealpixdggs-0.8.3.tar.gz", hash = "sha256:ad6c16a7d698fd4ee54d79d391d7891f1e309ea0b650acc5802b23ad819d2b78"},
 ]
 
 [package.dependencies]
@@ -2722,4 +2722,4 @@ s2 = ["s2geometry"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "deb2ef72bbc33cccfa05151ba9c7c046d4c9db4d0a587ac3144ded3aca91f545"
+content-hash = "d30ad1cc0a97ef30996b69f1e2a79b8fef9b264191bb6441b21c1381ac9d1c51"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2015,30 +2015,6 @@ scipy = ">=1.11"
 shapely = ">=2.1"
 
 [[package]]
-name = "rhppandas"
-version = "0.3.1"
-description = "Integration of rHEALPixDGGS and Pandas/GeoPandas"
-optional = true
-python-versions = ">=3.11"
-groups = ["main"]
-markers = "extra == \"rhp\" or extra == \"all\""
-files = [
-    {file = "rhppandas-0.3.1-py3-none-any.whl", hash = "sha256:1c29a42a163e0cc11dfa9c96b394b3bad77ead3cd058f874b3b5edbc3e3cf1f2"},
-    {file = "rhppandas-0.3.1.tar.gz", hash = "sha256:496f645613151bfb1d984c68bd99d5e4d22dccd5c8b652352203df1b633d1923"},
-]
-
-[package.dependencies]
-geopandas = "*"
-numpy = "*"
-pandas = "*"
-rhealpixdggs = ">=0.8.1"
-shapely = "*"
-typing-extensions = "*"
-
-[package.extras]
-dev = ["pytest", "pytest-cov"]
-
-[[package]]
 name = "rich"
 version = "15.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -2736,14 +2712,14 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [extras]
 a5 = ["pya5"]
-all = ["h3", "psycopg2-binary", "pya5", "python-geohash", "rhealpixdggs", "rhppandas", "rusty-polygon-geohasher", "s2geometry"]
+all = ["h3", "psycopg2-binary", "pya5", "python-geohash", "rhealpixdggs", "rusty-polygon-geohasher", "s2geometry"]
 geohash = ["python-geohash", "rusty-polygon-geohasher"]
 h3 = ["h3"]
 postgres = ["psycopg2-binary"]
-rhp = ["rhealpixdggs", "rhppandas"]
+rhp = ["rhealpixdggs"]
 s2 = ["s2geometry"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "df2dd4f63296f6faa671ce48805b7879a42e4c6f167ec831a784a3fcb93cf650"
+content-hash = "deb2ef72bbc33cccfa05151ba9c7c046d4c9db4d0a587ac3144ded3aca91f545"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ sqlalchemy = "^2.0.32"
 shapely = "^2.1"
 numpy = "^2"
 h3 = { version = "^4.1", optional = true }
-rhppandas = { version = "^0.3.1", optional = true}
 rhealpixdggs = { version = "^0.8.2", optional = true}
 s2geometry = { version = "^0.14.0", optional = true}
 rusty-polygon-geohasher = { version = "^0.2.3", optional = true}
@@ -74,10 +73,10 @@ check_untyped_defs = true
 
 [tool.poetry.extras]
 h3 = ["h3"]
-rhp = ["rhppandas", "rhealpixdggs"]
+rhp = ["rhealpixdggs"]
 s2 = ["s2geometry"]
 a5 = ["pya5"]
 geohash = ["rusty-polygon-geohasher", "python-geohash"]
 postgres = ["psycopg2-binary"]
 # Convenience extras
-all = ["h3", "rhppandas", "rhealpixdggs", "s2geometry", "rusty-polygon-geohasher", "python-geohash", "pya5", "psycopg2-binary"]
+all = ["h3", "rhealpixdggs", "s2geometry", "rusty-polygon-geohasher", "python-geohash", "pya5", "psycopg2-binary"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ sqlalchemy = "^2.0.32"
 shapely = "^2.1"
 numpy = "^2"
 h3 = { version = "^4.1", optional = true }
-rhealpixdggs = { version = "^0.8.2", optional = true}
+rhealpixdggs = { version = "^0.8.3", optional = true}
 s2geometry = { version = "^0.14.0", optional = true}
 rusty-polygon-geohasher = { version = "^0.2.3", optional = true}
 python-geohash = { version = "^0.8.5", optional = true}

--- a/tests/classes/batch_geometry.py
+++ b/tests/classes/batch_geometry.py
@@ -1,0 +1,77 @@
+from unittest import TestCase
+
+import geopandas as gpd
+from shapely.geometry import Point
+
+from vector2dggs.indexerfactory import indexer_instance
+
+from .base import skip_unless_backend
+
+
+class TestBatchCellGeometry(TestCase):
+    """
+    cells_to_points / cells_to_polygons must agree with the per-cell scalar
+    methods, across rHP cell shapes (quad, dart, cap) and mixed resolutions
+    (the compaction merge hands them a mixed-resolution index).
+    """
+
+    # caps (N4), darts (N0, S2), quads, at resolutions 0 through 5
+    RHP_CELLS = ["S", "N0", "N4", "S2", "P44", "N012", "Q333", "R88735"]
+
+    def test_rhp_batch_polygons_match_scalar(self):
+        skip_unless_backend("rhp")
+        idx = indexer_instance("rhp")
+        batch = list(idx.cells_to_polygons(self.RHP_CELLS))
+        self.assertEqual(len(batch), len(self.RHP_CELLS))
+        for cell, poly in zip(self.RHP_CELLS, batch, strict=True):
+            self.assertTrue(
+                poly.equals_exact(idx.cell_to_polygon(cell), tolerance=1e-9),
+                f"boundary mismatch for {cell}",
+            )
+
+    def test_rhp_batch_points_match_scalar(self):
+        skip_unless_backend("rhp")
+        idx = indexer_instance("rhp")
+        batch = list(idx.cells_to_points(self.RHP_CELLS))
+        for cell, point in zip(self.RHP_CELLS, batch, strict=True):
+            self.assertTrue(
+                point.equals_exact(idx.cell_to_point(cell), tolerance=1e-9),
+                f"centroid mismatch for {cell}",
+            )
+
+    def test_default_batch_methods_match_scalar(self):
+        skip_unless_backend("h3")
+        import h3
+
+        idx = indexer_instance("h3")
+        cells = [h3.latlng_to_cell(-41.3, 174.8, r) for r in (5, 9)]
+        self.assertEqual(
+            list(idx.cells_to_polygons(cells)),
+            [idx.cell_to_polygon(c) for c in cells],
+        )
+        self.assertEqual(
+            list(idx.cells_to_points(cells)),
+            [idx.cell_to_point(c) for c in cells],
+        )
+
+
+class TestBatchPointIndexing(TestCase):
+    """rHP point indexing over a whole frame must equal per-point lookup."""
+
+    POINTS = [Point(174.8, -41.3), Point(0.1, 0.2), Point(-176.3, -43.7)]
+
+    def test_rhp_points_batch_matches_scalar(self):
+        skip_unless_backend("rhp")
+        from rhealpixdggs.rhp_wrappers import geo_to_rhp
+
+        idx = indexer_instance("rhp")
+        df = gpd.GeoDataFrame(
+            {"fid": range(len(self.POINTS)), "geometry": self.POINTS}, crs=4326
+        )
+        out = idx._polyfill_points(df.copy(), 7)
+        expected = {
+            (geo_to_rhp(p.y, p.x, 7, plane=False), i) for i, p in enumerate(self.POINTS)
+        }
+        self.assertEqual(set(zip(out.index, out["fid"], strict=True)), expected)
+        self.assertIsNone(out.index.name)
+        self.assertNotIn("geometry", out.columns)

--- a/tests/classes/linetrace.py
+++ b/tests/classes/linetrace.py
@@ -1,7 +1,6 @@
 from unittest import TestCase, mock
 
 import geopandas as gpd
-import pandas as pd
 from shapely.geometry import LineString
 
 from vector2dggs.indexerfactory import indexer_instance
@@ -82,18 +81,14 @@ class TestEmptyTraces(TestCase):
         df = gpd.GeoDataFrame(
             {"fid": [0, 1], "geometry": [self.LINE, self.LINE]}, crs=4326
         )
-        accessor_cls = type(df.rhp)
-        real = accessor_cls.linetrace
+        real = type(indexer)._linetrace
+        calls = iter([True, False])
 
-        def fake(self_acc, resolution):
-            out = real(self_acc, resolution)
-            col = out.columns[-1]
-            values = out[col].tolist()
-            values[0] = []
-            out[col] = pd.Series(values, index=out.index)
-            return out
+        def fake(geom, resolution):
+            # the upstream wrapper returns None for untraceable lines
+            return None if next(calls) else real(geom, resolution)
 
-        with mock.patch.object(accessor_cls, "linetrace", fake):
+        with mock.patch.object(type(indexer), "_linetrace", staticmethod(fake)):
             result = indexer._polyfill_linestrings(df, 6)
         self._assert_no_nan_rows(indexer, result, 1)
 

--- a/tests/classes/write_limits.py
+++ b/tests/classes/write_limits.py
@@ -51,7 +51,7 @@ class TestSortedHiveWrite(TestCase):
         ):
             common.write_partition(
                 df,
-                H3VectorIndexer.cell_to_polygon,
+                H3VectorIndexer(dggs="h3").cells_to_polygons,
                 Path(out),
                 "h3_08",
                 "h3_12",
@@ -88,7 +88,7 @@ class TestSortedHiveWrite(TestCase):
         with tempfile.TemporaryDirectory() as out:
             common.write_partition(
                 df,
-                H3VectorIndexer.cell_to_polygon,
+                H3VectorIndexer(dggs="h3").cells_to_polygons,
                 Path(out),
                 "h3_08",
                 "h3_09",

--- a/tests/test_runthrough.py
+++ b/tests/test_runthrough.py
@@ -118,6 +118,8 @@ with contextlib.suppress(ImportError):
 with contextlib.suppress(ImportError):
     from .classes.errors import TestStagedOutput as TestStagedOutput
 with contextlib.suppress(ImportError):
+    from .classes.batch_geometry import TestBatchCellGeometry as TestBatchCellGeometry
+    from .classes.batch_geometry import TestBatchPointIndexing as TestBatchPointIndexing
     from .classes.ingest import TestBatchedIngest as TestBatchedIngest
     from .classes.ingest import TestDefaultLayer as TestDefaultLayer
 with contextlib.suppress(ImportError):

--- a/vector2dggs/common.py
+++ b/vector2dggs/common.py
@@ -381,7 +381,7 @@ def write_partition(
     # form, before any string conversion below.
     if geo_serialisation_method is not None:
         partition_df["geometry"] = shapely.to_wkb(
-            cell_ids.map(geo_serialisation_method), hex=False
+            np.asarray(geo_serialisation_method(cell_ids.to_numpy())), hex=False
         )
 
     # The parent/partition column decides the hive directory name, created
@@ -486,12 +486,13 @@ def _with_geoparquet_metadata(table: pa.Table) -> pa.Table:
 
 
 def _geom_fn(indexer: VectorIndexer, geo: str):
+    """Returns a batch cells -> geometries callable, or None."""
     if geo == const.GeoOutputMode.NONE.value:
         return None
     if geo == const.GeoOutputMode.POINT.value:
-        return indexer.cell_to_point
+        return indexer.cells_to_points
     if geo == const.GeoOutputMode.POLYGON.value:
-        return indexer.cell_to_polygon
+        return indexer.cells_to_polygons
     raise ValueError(
         f"Unknown geo output mode '{geo}'. Expected one of {const.GEOM_TYPES}."
     )
@@ -599,8 +600,11 @@ def _merge_partition_files(
         )
         geom_fn = _geom_fn(indexer, geo) if geo else None
         if geom_fn is not None:
-            cells = df.index.to_series(index=df.index)
-            df = df.assign(geometry=shapely.to_wkb(cells.map(geom_fn), hex=False))
+            df = df.assign(
+                geometry=shapely.to_wkb(
+                    np.asarray(geom_fn(df.index.to_numpy())), hex=False
+                )
+            )
 
         # Compaction and geometry reconstruction both need the working
         # (native, for capable backends) cell form; string output - the

--- a/vector2dggs/indexers/rhpvectorindexer.py
+++ b/vector2dggs/indexers/rhpvectorindexer.py
@@ -3,12 +3,12 @@ from itertools import product
 
 import geopandas as gpd
 import pandas as pd
+import shapely
 from rhealpixdggs.dggs import WGS84_003
 from rhealpixdggs.rhp_wrappers import (
     compact_cells as rhp_compact_cells,
 )
 from rhealpixdggs.rhp_wrappers import (
-    geo_to_rhp,
     linetrace,
     polyfill,
     rhp_get_resolution,
@@ -50,12 +50,20 @@ class RHPVectorIndexer(VectorIndexer[str]):
         return self._geo_to_cells(df, resolution, self._linetrace, df.geometry.name)
 
     def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
-        return self._geo_to_cells(
-            df,
-            resolution,
-            lambda geom, res: [geo_to_rhp(geom.y, geom.x, res, plane=False)],
-            df.geometry.name,
+        geom = df[df.geometry.name]
+        cells = WGS84_003.cells_from_points(
+            geom.x.to_numpy(), geom.y.to_numpy(), resolution, plane=False
         )
+        result = df.drop(columns=[df.geometry.name])
+        result.index = pd.Index(cells.astype(object))
+        # empty string marks a point outside the planar image (no cell)
+        return pd.DataFrame(result[result.index != ""].rename_axis(None))
+
+    def cells_to_points(self, cells: Iterable[str]) -> Iterable[Point]:
+        return shapely.points(WGS84_003.centroids(list(cells), plane=False))
+
+    def cells_to_polygons(self, cells: Iterable[str]) -> Iterable[Polygon]:
+        return shapely.polygons(WGS84_003.boundary_array(list(cells), n=2, plane=False))
 
     def secondary_index(self, df: pd.DataFrame, parent_res: int) -> pd.DataFrame:
         """

--- a/vector2dggs/indexers/rhpvectorindexer.py
+++ b/vector2dggs/indexers/rhpvectorindexer.py
@@ -3,18 +3,19 @@ from itertools import product
 
 import geopandas as gpd
 import pandas as pd
-import rhppandas as rhppandas  # registers the .rhp accessor used below
 from rhealpixdggs.dggs import WGS84_003
 from rhealpixdggs.rhp_wrappers import (
     compact_cells as rhp_compact_cells,
 )
 from rhealpixdggs.rhp_wrappers import (
+    geo_to_rhp,
+    linetrace,
+    polyfill,
     rhp_get_resolution,
     rhp_to_center_child,
     rhp_to_geo,
     rhp_to_geo_boundary,
 )
-from rhppandas.util.const import COLUMNS
 from shapely.geometry import Point, Polygon
 
 from vector2dggs.indexers.vectorindexer import VectorIndexer
@@ -27,40 +28,45 @@ class RHPVectorIndexer(VectorIndexer[str]):
 
     GEODESIC_POLYFILL = False
 
+    @staticmethod
+    def _polyfill_polygon(geom, resolution: int) -> list:
+        cells = polyfill(geom, resolution, plane=False, dggs=WGS84_003)
+        return list(cells) if cells else []
+
+    @staticmethod
+    def _linetrace(geom, resolution: int) -> list:
+        cells = linetrace(geom, resolution, plane=False, dggs=WGS84_003)
+        # linetrace returns a traversal sequence, which may revisit cells
+        return list(dict.fromkeys(cells)) if cells else []
+
     def _polyfill_polygons(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
-        geom_col = df.geometry.name
-        result = df.rhp.polyfill_resample(
-            resolution, return_geometry=False, compress=False
-        ).drop(columns=["index", geom_col])
-        return pd.DataFrame(result)
+        return self._geo_to_cells(
+            df, resolution, self._polyfill_polygon, df.geometry.name
+        )
 
     def _polyfill_linestrings(
         self, df: gpd.GeoDataFrame, resolution: int
     ) -> pd.DataFrame:
-        geom_col = df.geometry.name
-        col = COLUMNS["linetrace"]
-        result = df.rhp.linetrace(resolution)
-        # linetrace returns a traversal sequence, which may revisit cells
-        result[col] = result[col].map(lambda cells: list(dict.fromkeys(cells)))
-        result = (
-            result.drop(columns=[geom_col])
-            .explode(col)
-            .dropna(subset=[col])
-            .set_index(col)
-        )
-        return pd.DataFrame(result)
+        return self._geo_to_cells(df, resolution, self._linetrace, df.geometry.name)
 
     def _polyfill_points(self, df: gpd.GeoDataFrame, resolution: int) -> pd.DataFrame:
-        geom_col = df.geometry.name
-        result = df.rhp.geo_to_rhp(resolution, set_index=True)
-        return pd.DataFrame(result.drop(columns=[geom_col]))
+        return self._geo_to_cells(
+            df,
+            resolution,
+            lambda geom, res: [geo_to_rhp(geom.y, geom.x, res, plane=False)],
+            df.geometry.name,
+        )
 
     def secondary_index(self, df: pd.DataFrame, parent_res: int) -> pd.DataFrame:
         """
         Implementation of abstract function.
-        """
 
-        return df.rhp.rhp_to_parent(parent_res)
+        A cell's ancestor at parent_res is its address prefix (the rHEALPix
+        addressing convention), so this is a vectorised string slice rather
+        than a per-cell library call.
+        """
+        df[f"rhp_{parent_res:02}"] = df.index.str[: parent_res + 1]
+        return df
 
     def compaction(
         self,

--- a/vector2dggs/indexers/vectorindexer.py
+++ b/vector2dggs/indexers/vectorindexer.py
@@ -108,6 +108,20 @@ class VectorIndexer(ABC, Generic[CellId]):
     @abstractmethod
     def cell_to_polygon(cell: CellId) -> Polygon: ...
 
+    def cells_to_points(self, cells: Iterable[CellId]) -> Iterable[Point]:
+        """
+        Batch form of cell_to_point; backends with a vectorised cell-to-
+        geometry API override this.
+        """
+        return [self.cell_to_point(c) for c in cells]
+
+    def cells_to_polygons(self, cells: Iterable[CellId]) -> Iterable[Polygon]:
+        """
+        Batch form of cell_to_polygon; backends with a vectorised cell-to-
+        geometry API override this.
+        """
+        return [self.cell_to_polygon(c) for c in cells]
+
     @staticmethod
     @abstractmethod
     def get_resolution(cell: CellId) -> int: ...


### PR DESCRIPTION
Two related changes to the rHEALPix backend.

**Drop rhppandas.** The rHP indexer now calls `rhealpixdggs.rhp_wrappers` directly, through the same per-geometry helper the h3 indexer uses; rhppandas leaves the dependencies and extras. Parent-cell assignment (`secondary_index`) becomes a vectorised string slice — a cell's ancestor is its address prefix — measured ~80× faster (2.5 s → 0.03 s per million cells) with identical output. Polyfill wall time is unchanged (the cost is inside `cells_from_region` either way); all outputs verified identical.

**Adopt the 0.8.3 array APIs.** `rhealpixdggs` 0.8.3 added vectorised, string-in/array-out functions (`boundary_array`, `centroids`, `cells_from_points`). The indexer interface gains batch `cells_to_points`/`cells_to_polygons` methods — defaulting to a loop over the existing scalar methods, so other backends are unchanged — and both `--geo` geometry-construction sites (worker writes and the compaction merge, which passes mixed-resolution cells) now make one batch call per frame. rHP overrides them with the array functions, and indexes point layers with a single `cells_from_points` call instead of a per-point lookup.

Measured on real runs (identical outputs in every case, geometry equal to within last-bit float noise): point indexing end-to-end 21.5 s → 5.8 s for 300k points with `--geo polygon`; polygon-geometry regeneration 49× in isolation (4.9 s → 0.1 s per 33k mixed-resolution cells). Coarse compacted polygon runs are unchanged — they're bound by polygon polyfill inside rhealpixdggs, which this doesn't touch.

Equivalence pinned by tests: batch-vs-scalar across quad/dart/cap cell shapes and mixed resolutions, the scalar fallback for h3, and point-indexing parity. Requires `rhealpixdggs >= 0.8.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
